### PR TITLE
Add skeleton for persistent JIT cache

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,7 @@ wx-resources.cpp : pc.xrc
 
 # PCem
 pcem_SOURCES = 386.c 386_common.c 386_dynarec.c 386_dynarec_ops.c 808x.c acc2036.c acer386sx.c ali1429.c  amstrad.c cbm_io.c cdrom-image.cc cdrom-null.c \
-cmd640.c codegen.c codegen_accumulate.c codegen_allocator.c codegen_backend.c codegen_ir.c codegen_ops.c codegen_ops_3dnow.c codegen_ops_arith.c codegen_ops_branch.c codegen_ops_fpu_arith.c codegen_ops_fpu_constant.c codegen_ops_fpu_loadstore.c codegen_ops_fpu_misc.c codegen_ops_helpers.c codegen_ops_jump.c codegen_ops_logic.c codegen_ops_shift.c \
+cmd640.c codegen.c codegen_accumulate.c codegen_allocator.c codegen_backend.c codegen_ir.c jit_cache.c codegen_ops.c codegen_ops_3dnow.c codegen_ops_arith.c codegen_ops_branch.c codegen_ops_fpu_arith.c codegen_ops_fpu_constant.c codegen_ops_fpu_loadstore.c codegen_ops_fpu_misc.c codegen_ops_helpers.c codegen_ops_jump.c codegen_ops_logic.c codegen_ops_shift.c \
 codegen_ops_misc.c codegen_ops_mov.c codegen_ops_stack.c codegen_reg.c codegen_timing_486.c codegen_timing_686.c codegen_timing_common.c codegen_timing_k6.c codegen_timing_pentium.c codegen_timing_winchip.c codegen_timing_winchip2.c compaq.c config.c cpu.c \
 cpu_tables.c dells200.c device.c disc.c disc_fdi.c disc_img.c disc_sector.c dma.c esdi_at.c fdc.c fdc37c665.c fdd.c fdi2raw.c gameport.c \
 hdd.c hdd_esdi.c hdd_file.c headland.c i430lx.c i430fx.c i430vx.c ide.c ide_atapi.c ide_sff8038i.c intel.c intel_flash.c io.c jim.c joystick_ch_flightstick_pro.c joystick_standard.c joystick_sw_pad.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -141,8 +141,8 @@ am__installdirs = "$(DESTDIR)$(bindir)"
 PROGRAMS = $(bin_PROGRAMS)
 am__pcem_SOURCES_DIST = 386.c 386_dynarec.c 386_dynarec_ops.c 808x.c \
 	acc2036.c acer386sx.c ali1429.c amstrad.c cbm_io.c \
-	cdrom-image.cc cdrom-null.c cmd640.c codegen.c \
-	codegen_backend.c codegen_ir.c codegen_timing_486.c \
+        cdrom-image.cc cdrom-null.c cmd640.c codegen.c \
+        codegen_backend.c codegen_ir.c jit_cache.c codegen_timing_486.c \
 	codegen_timing_686.c codegen_timing_common.c \
 	codegen_timing_pentium.c codegen_timing_winchip.c compaq.c \
 	config.c cpu.c dells200.c device.c disc.c disc_fdi.c \
@@ -769,7 +769,7 @@ WINDRES = $(shell $(WX_CONFIG_PATH) --rescomp)
 # resid-fp
 pcem_SOURCES = 386.c 386_dynarec.c 386_dynarec_ops.c 808x.c acc2036.c \
 	acer386sx.c ali1429.c amstrad.c cbm_io.c cdrom-image.cc \
-	cdrom-null.c cmd640.c codegen.c codegen_backend.c codegen_ir.c \
+        cdrom-null.c cmd640.c codegen.c codegen_backend.c codegen_ir.c jit_cache.c \
 	codegen_timing_486.c codegen_timing_686.c \
 	codegen_timing_common.c codegen_timing_pentium.c \
 	codegen_timing_winchip.c compaq.c config.c cpu.c dells200.c \

--- a/src/jit_cache.c
+++ b/src/jit_cache.c
@@ -1,0 +1,42 @@
+#include "jit_cache.h"
+#include "config.h"
+#include "paths.h"
+#include "codegen.h"
+#include <stdio.h>
+#include <string.h>
+
+void jit_cache_load(const char *path)
+{
+    char fullpath[512];
+    if (!path)
+    {
+        append_filename(fullpath, configs_path, JIT_CACHE_FILENAME, 511);
+        path = fullpath;
+    }
+
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        return;
+
+    /* TODO: implement loading of JIT cache */
+
+    fclose(f);
+}
+
+void jit_cache_save(const char *path)
+{
+    char fullpath[512];
+    if (!path)
+    {
+        append_filename(fullpath, configs_path, JIT_CACHE_FILENAME, 511);
+        path = fullpath;
+    }
+
+    FILE *f = fopen(path, "wb");
+    if (!f)
+        return;
+
+    /* TODO: implement saving of JIT cache */
+
+    fclose(f);
+}

--- a/src/jit_cache.h
+++ b/src/jit_cache.h
@@ -1,0 +1,9 @@
+#ifndef JIT_CACHE_H
+#define JIT_CACHE_H
+
+#define JIT_CACHE_FILENAME "jit_cache.bin"
+
+void jit_cache_load(const char *path);
+void jit_cache_save(const char *path);
+
+#endif /* JIT_CACHE_H */

--- a/src/pc.c
+++ b/src/pc.c
@@ -52,6 +52,7 @@
 #include "hdd.h"
 #include "x86.h"
 #include "paths.h"
+#include "jit_cache.h"
 
 #ifdef USE_NETWORKING
 #include "nethandler.h"
@@ -307,6 +308,7 @@ void initpc(int argc, char *argv[])
         mem_add_bios();
                         
         codegen_init();
+        jit_cache_load(NULL);
         
         timer_reset();
         sound_reset();
@@ -615,6 +617,7 @@ void speedchanged()
 
 void closepc()
 {
+        jit_cache_save(NULL);
         codegen_close();
         atapi->exit();
 //        ioctl_close();


### PR DESCRIPTION
## Summary
- add `jit_cache.c` and `jit_cache.h` with placeholder save/load
- integrate JIT cache hooks into `pc.c`
- update build files to compile the new module

## Testing
- `./configure --enable-release` *(fails: wxWidgets missing)*
- `make -j$(nproc)` *(fails: No makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6880fc8832cb20a18a62b52d6c7