### PR TITLE
Add serialization logic for JIT cache

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,7 @@ wx-resources.cpp : pc.xrc
 
 # PCem
 pcem_SOURCES = 386.c 386_common.c 386_dynarec.c 386_dynarec_ops.c 808x.c acc2036.c acer386sx.c ali1429.c  amstrad.c cbm_io.c cdrom-image.cc cdrom-null.c \
-cmd640.c codegen.c codegen_accumulate.c codegen_allocator.c codegen_backend.c codegen_ir.c codegen_ops.c codegen_ops_3dnow.c codegen_ops_arith.c codegen_ops_branch.c codegen_ops_fpu_arith.c codegen_ops_fpu_constant.c codegen_ops_fpu_loadstore.c codegen_ops_fpu_misc.c codegen_ops_helpers.c codegen_ops_jump.c codegen_ops_logic.c codegen_ops_shift.c \
+cmd640.c codegen.c codegen_accumulate.c codegen_allocator.c codegen_backend.c codegen_ir.c jit_cache.c codegen_ops.c codegen_ops_3dnow.c codegen_ops_arith.c codegen_ops_branch.c codegen_ops_fpu_arith.c codegen_ops_fpu_constant.c codegen_ops_fpu_loadstore.c codegen_ops_fpu_misc.c codegen_ops_helpers.c codegen_ops_jump.c codegen_ops_logic.c codegen_ops_shift.c \
 codegen_ops_misc.c codegen_ops_mov.c codegen_ops_stack.c codegen_reg.c codegen_timing_486.c codegen_timing_686.c codegen_timing_common.c codegen_timing_k6.c codegen_timing_pentium.c codegen_timing_winchip.c codegen_timing_winchip2.c compaq.c config.c cpu.c \
 cpu_tables.c dells200.c device.c disc.c disc_fdi.c disc_img.c disc_sector.c dma.c esdi_at.c fdc.c fdc37c665.c fdd.c fdi2raw.c gameport.c \
 hdd.c hdd_esdi.c hdd_file.c headland.c i430lx.c i430fx.c i430vx.c ide.c ide_atapi.c ide_sff8038i.c intel.c intel_flash.c io.c jim.c joystick_ch_flightstick_pro.c joystick_standard.c joystick_sw_pad.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -141,8 +141,8 @@ am__installdirs = "$(DESTDIR)$(bindir)"
 PROGRAMS = $(bin_PROGRAMS)
 am__pcem_SOURCES_DIST = 386.c 386_dynarec.c 386_dynarec_ops.c 808x.c \
 	acc2036.c acer386sx.c ali1429.c amstrad.c cbm_io.c \
-	cdrom-image.cc cdrom-null.c cmd640.c codegen.c \
-	codegen_backend.c codegen_ir.c codegen_timing_486.c \
+        cdrom-image.cc cdrom-null.c cmd640.c codegen.c \
+        codegen_backend.c codegen_ir.c jit_cache.c codegen_timing_486.c \
 	codegen_timing_686.c codegen_timing_common.c \
 	codegen_timing_pentium.c codegen_timing_winchip.c compaq.c \
 	config.c cpu.c dells200.c device.c disc.c disc_fdi.c \
@@ -769,7 +769,7 @@ WINDRES = $(shell $(WX_CONFIG_PATH) --rescomp)
 # resid-fp
 pcem_SOURCES = 386.c 386_dynarec.c 386_dynarec_ops.c 808x.c acc2036.c \
 	acer386sx.c ali1429.c amstrad.c cbm_io.c cdrom-image.cc \
-	cdrom-null.c cmd640.c codegen.c codegen_backend.c codegen_ir.c \
+        cdrom-null.c cmd640.c codegen.c codegen_backend.c codegen_ir.c jit_cache.c \
 	codegen_timing_486.c codegen_timing_686.c \
 	codegen_timing_common.c codegen_timing_pentium.c \
 	codegen_timing_winchip.c compaq.c config.c cpu.c dells200.c \

--- a/src/codegen_allocator.c
+++ b/src/codegen_allocator.c
@@ -130,6 +130,14 @@ void codegen_allocator_state_load(FILE *f)
     fread(&mem_block_free_list, sizeof(mem_block_free_list), 1, f);
     fread(mem_blocks, sizeof(mem_blocks), 1, f);
     fread(mem_block_alloc, MEM_BLOCK_NR * MEM_BLOCK_SIZE, 1, f);
+#if defined __ARM_EABI__ || defined __aarch64__
+    for (int i = 0; i < MEM_BLOCK_NR; i++)
+    {
+        if (mem_blocks[i].code_block != BLOCK_INVALID)
+            __clear_cache(&mem_block_alloc[mem_blocks[i].offset],
+                           &mem_block_alloc[mem_blocks[i].offset + MEM_BLOCK_SIZE]);
+    }
+#endif
 }
 
 int codegen_allocator_block_index(struct mem_block_t *block)

--- a/src/codegen_allocator.c
+++ b/src/codegen_allocator.c
@@ -10,13 +10,6 @@
 #include "codegen.h"
 #include "codegen_allocator.h"
 
-typedef struct mem_block_t
-{
-        uint32_t offset; /*Offset into mem_block_alloc*/
-        uint32_t next;
-        uint16_t code_block;
-} mem_block_t;
-
 static mem_block_t mem_blocks[MEM_BLOCK_NR];
 static uint32_t mem_block_free_list;
 static uint8_t *mem_block_alloc = NULL;
@@ -123,4 +116,32 @@ void codegen_allocator_clean_blocks(struct mem_block_t *block)
 			break;
         }
 #endif
+}
+
+void codegen_allocator_state_save(FILE *f)
+{
+    fwrite(&mem_block_free_list, sizeof(mem_block_free_list), 1, f);
+    fwrite(mem_blocks, sizeof(mem_blocks), 1, f);
+    fwrite(mem_block_alloc, MEM_BLOCK_NR * MEM_BLOCK_SIZE, 1, f);
+}
+
+void codegen_allocator_state_load(FILE *f)
+{
+    fread(&mem_block_free_list, sizeof(mem_block_free_list), 1, f);
+    fread(mem_blocks, sizeof(mem_blocks), 1, f);
+    fread(mem_block_alloc, MEM_BLOCK_NR * MEM_BLOCK_SIZE, 1, f);
+}
+
+int codegen_allocator_block_index(struct mem_block_t *block)
+{
+    if (!block)
+        return 0;
+    return (block - mem_blocks) + 1;
+}
+
+struct mem_block_t *codegen_allocator_index_block(int index)
+{
+    if (!index)
+        return NULL;
+    return &mem_blocks[index - 1];
 }

--- a/src/codegen_allocator.h
+++ b/src/codegen_allocator.h
@@ -22,6 +22,15 @@
 #define MEM_BLOCK_MASK (MEM_BLOCK_NR-1)
 #define MEM_BLOCK_SIZE 0x3c0
 
+#include <stdio.h>
+
+typedef struct mem_block_t
+{
+    uint32_t offset; /*Offset into mem_block_alloc*/
+    uint32_t next;
+    uint16_t code_block;
+} mem_block_t;
+
 void codegen_allocator_init();
 /*Allocate a mem_block_t, and the associated backing memory.
   If parent is non-NULL, then the new block will be added to the list in
@@ -33,6 +42,14 @@ void codegen_allocator_free(struct mem_block_t *block);
 uint8_t *codeblock_allocator_get_ptr(struct mem_block_t *block);
 /*Cache clean memory block list*/
 void codegen_allocator_clean_blocks(struct mem_block_t *block);
+
+/*Save/restore allocator state*/
+void codegen_allocator_state_save(FILE *f);
+void codegen_allocator_state_load(FILE *f);
+
+/*Convert between mem_block_t pointer and index used for serialization*/
+int codegen_allocator_block_index(struct mem_block_t *block);
+struct mem_block_t *codegen_allocator_index_block(int index);
 
 extern int codegen_allocator_usage;
 

--- a/src/codegen_backend.c
+++ b/src/codegen_backend.c
@@ -826,6 +826,102 @@ void codegen_block_end_recompile(codeblock_t *block)
         codegen_ir_compile(ir_data, block);
 }
 
+typedef struct {
+    uint32_t pc, _cs, phys, phys_2;
+    uint16_t status, flags;
+    uint8_t ins, TOP;
+    uint16_t parent, left, right;
+    uint64_t page_mask, page_mask2;
+    uint16_t prev, next;
+    uint16_t prev_2, next_2;
+    uint32_t head_mem_block;
+} codeblock_disk_t;
+
+void codegen_state_save(FILE *f)
+{
+    fwrite(&block_free_list, sizeof(block_free_list), 1, f);
+    fwrite(&block_dirty_list_head, sizeof(block_dirty_list_head), 1, f);
+    fwrite(&block_dirty_list_tail, sizeof(block_dirty_list_tail), 1, f);
+    fwrite(&dirty_list_size, sizeof(dirty_list_size), 1, f);
+    fwrite(&block_current, sizeof(block_current), 1, f);
+    fwrite(&block_pos, sizeof(block_pos), 1, f);
+
+    for (int i = 0; i < BLOCK_SIZE; i++)
+    {
+        codeblock_disk_t d;
+        codeblock_t *b = &codeblock[i];
+        d.pc = b->pc;
+        d._cs = b->_cs;
+        d.phys = b->phys;
+        d.phys_2 = b->phys_2;
+        d.status = b->status;
+        d.flags = b->flags;
+        d.ins = b->ins;
+        d.TOP = b->TOP;
+        d.parent = b->parent;
+        d.left = b->left;
+        d.right = b->right;
+        d.page_mask = b->page_mask;
+        d.page_mask2 = b->page_mask2;
+        d.prev = b->prev;
+        d.next = b->next;
+        d.prev_2 = b->prev_2;
+        d.next_2 = b->next_2;
+        d.head_mem_block = codegen_allocator_block_index(b->head_mem_block);
+        fwrite(&d, sizeof(d), 1, f);
+    }
+    fwrite(codeblock_hash, sizeof(uint16_t), HASH_SIZE, f);
+}
+
+void codegen_state_load(FILE *f)
+{
+    fread(&block_free_list, sizeof(block_free_list), 1, f);
+    fread(&block_dirty_list_head, sizeof(block_dirty_list_head), 1, f);
+    fread(&block_dirty_list_tail, sizeof(block_dirty_list_tail), 1, f);
+    fread(&dirty_list_size, sizeof(dirty_list_size), 1, f);
+    fread(&block_current, sizeof(block_current), 1, f);
+    fread(&block_pos, sizeof(block_pos), 1, f);
+
+    for (int i = 0; i < BLOCK_SIZE; i++)
+    {
+        codeblock_disk_t d;
+        fread(&d, sizeof(d), 1, f);
+        codeblock_t *b = &codeblock[i];
+        b->pc = d.pc;
+        b->_cs = d._cs;
+        b->phys = d.phys;
+        b->phys_2 = d.phys_2;
+        b->status = d.status;
+        b->flags = d.flags;
+        b->ins = d.ins;
+        b->TOP = d.TOP;
+        b->parent = d.parent;
+        b->left = d.left;
+        b->right = d.right;
+        b->page_mask = d.page_mask;
+        b->page_mask2 = d.page_mask2;
+        b->prev = d.prev;
+        b->next = d.next;
+        b->prev_2 = d.prev_2;
+        b->next_2 = d.next_2;
+        b->head_mem_block = codegen_allocator_index_block(d.head_mem_block);
+        if (b->pc != BLOCK_PC_INVALID)
+        {
+            b->dirty_mask = &pages[b->phys >> 12].dirty_mask;
+            if (b->page_mask2)
+                b->dirty_mask2 = &pages[b->phys_2 >> 12].dirty_mask;
+            else
+                b->dirty_mask2 = NULL;
+        }
+        else
+        {
+            b->dirty_mask = NULL;
+            b->dirty_mask2 = NULL;
+        }
+    }
+    fread(codeblock_hash, sizeof(uint16_t), HASH_SIZE, f);
+}
+
 void codegen_flush()
 {
         return;
@@ -887,3 +983,4 @@ void codegen_mark_code_present_multibyte(codeblock_t *block, uint32_t start_pc, 
                 }
         }
 }
+

--- a/src/codegen_backend.c
+++ b/src/codegen_backend.c
@@ -882,6 +882,8 @@ void codegen_state_load(FILE *f)
     fread(&block_current, sizeof(block_current), 1, f);
     fread(&block_pos, sizeof(block_pos), 1, f);
 
+    mem_reset_page_blocks();
+
     for (int i = 0; i < BLOCK_SIZE; i++)
     {
         codeblock_disk_t d;
@@ -912,11 +914,20 @@ void codegen_state_load(FILE *f)
                 b->dirty_mask2 = &pages[b->phys_2 >> 12].dirty_mask;
             else
                 b->dirty_mask2 = NULL;
+            b->data = codeblock_allocator_get_ptr(b->head_mem_block);
+
+            if (b->prev == BLOCK_INVALID)
+                pages[b->phys >> 12].block = get_block_nr(b);
+            if ((b->flags & CODEBLOCK_HAS_PAGE2) && b->prev_2 == BLOCK_INVALID)
+                pages[b->phys_2 >> 12].block_2 = get_block_nr(b);
+            if (b->parent == BLOCK_INVALID)
+                pages[b->phys >> 12].head = get_block_nr(b);
         }
         else
         {
             b->dirty_mask = NULL;
             b->dirty_mask2 = NULL;
+            b->data = NULL;
         }
     }
     fread(codeblock_hash, sizeof(uint16_t), HASH_SIZE, f);

--- a/src/codegen_backend.h
+++ b/src/codegen_backend.h
@@ -27,3 +27,7 @@ extern const uOpFn uop_handlers[];
 
 extern int codegen_host_reg_list[CODEGEN_HOST_REGS];
 extern int codegen_host_fp_reg_list[CODEGEN_HOST_FP_REGS];
+
+#include <stdio.h>
+void codegen_state_save(FILE *f);
+void codegen_state_load(FILE *f);

--- a/src/jit_cache.c
+++ b/src/jit_cache.c
@@ -1,0 +1,60 @@
+#include "jit_cache.h"
+#include "config.h"
+#include "paths.h"
+#include "codegen.h"
+#include "codegen_allocator.h"
+#include "codegen_backend.h"
+#include <stdio.h>
+#include <string.h>
+
+void jit_cache_load(const char *path)
+{
+    char fullpath[512];
+    if (!path)
+    {
+        append_filename(fullpath, configs_path, JIT_CACHE_FILENAME, 511);
+        path = fullpath;
+    }
+
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        return;
+
+    uint32_t magic, version;
+    fread(&magic, sizeof(magic), 1, f);
+    fread(&version, sizeof(version), 1, f);
+    if (magic != 0x4a495443 || version != 1)
+    {
+        fclose(f);
+        return;
+    }
+
+    codegen_allocator_state_load(f);
+    codegen_state_load(f);
+
+    fclose(f);
+}
+
+void jit_cache_save(const char *path)
+{
+    char fullpath[512];
+    if (!path)
+    {
+        append_filename(fullpath, configs_path, JIT_CACHE_FILENAME, 511);
+        path = fullpath;
+    }
+
+    FILE *f = fopen(path, "wb");
+    if (!f)
+        return;
+
+    uint32_t magic = 0x4a495443;
+    uint32_t version = 1;
+    fwrite(&magic, sizeof(magic), 1, f);
+    fwrite(&version, sizeof(version), 1, f);
+
+    codegen_allocator_state_save(f);
+    codegen_state_save(f);
+
+    fclose(f);
+}

--- a/src/jit_cache.h
+++ b/src/jit_cache.h
@@ -1,0 +1,9 @@
+#ifndef JIT_CACHE_H
+#define JIT_CACHE_H
+
+#define JIT_CACHE_FILENAME "jit_cache.bin"
+
+void jit_cache_load(const char *path);
+void jit_cache_save(const char *path);
+
+#endif /* JIT_CACHE_H */

--- a/src/pc.c
+++ b/src/pc.c
@@ -52,6 +52,7 @@
 #include "hdd.h"
 #include "x86.h"
 #include "paths.h"
+#include "jit_cache.h"
 
 #ifdef USE_NETWORKING
 #include "nethandler.h"
@@ -307,6 +308,7 @@ void initpc(int argc, char *argv[])
         mem_add_bios();
                         
         codegen_init();
+        jit_cache_load(NULL);
         
         timer_reset();
         sound_reset();
@@ -615,6 +617,7 @@ void speedchanged()
 
 void closepc()
 {
+        jit_cache_save(NULL);
         codegen_close();
         atapi->exit();
 //        ioctl_close();


### PR DESCRIPTION
## Summary
- expose memory block struct and serialization helpers
- add save/load helpers for code generator state
- implement persistence in `jit_cache.c`
- hook cache load/save into PC initialization and shutdown

## Testing
- `./configure --enable-release` *(fails: wxWidgets missing)*
- `make -j$(nproc)` *(fails: No makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6880fc8832cb20a18a62b52d6c7