### PR TITLE
Add dynamic recompiler cache

### DIFF
--- a/includes/private/codegen/codegen.h
+++ b/includes/private/codegen/codegen.h
@@ -56,6 +56,13 @@ typedef struct codeblock_t {
         /*First mem_block_t used by this block. Any subsequent mem_block_ts
           will be in the list starting at head_mem_block->next.*/
         struct mem_block_t *head_mem_block;
+
+        /*Size of compiled code in bytes*/
+        uint32_t compiled_size;
+        /*Final position within the last memory block*/
+        int last_pos;
+        /*CRC32 of the original instruction bytes*/
+        uint32_t crc;
 } codeblock_t;
 
 extern codeblock_t *codeblock;

--- a/includes/private/codegen/codegen_allocator.h
+++ b/includes/private/codegen/codegen_allocator.h
@@ -34,6 +34,13 @@ uint8_t *codeblock_allocator_get_ptr(struct mem_block_t *block);
 /*Cache clean memory block list*/
 void codegen_allocator_clean_blocks(struct mem_block_t *block);
 
+/*Return total size of memory used by block chain*/
+size_t codeblock_allocator_get_size(struct mem_block_t *block, int last_pos);
+/*Copy memory from block chain into buffer*/
+size_t codeblock_allocator_copy(struct mem_block_t *block, int last_pos, uint8_t *dest);
+/*Write buffer contents into block chain*/
+void codeblock_allocator_write(struct mem_block_t *block, int last_pos, const uint8_t *src);
+
 extern int codegen_allocator_usage;
 
 #endif /* _CODEGEN_ALLOCATOR_H_ */

--- a/includes/private/codegen/codegen_cache.h
+++ b/includes/private/codegen/codegen_cache.h
@@ -1,0 +1,14 @@
+#ifndef _CODEGEN_CACHE_H_
+#define _CODEGEN_CACHE_H_
+#include <stdint.h>
+#include <stddef.h>
+#include "codegen_allocator.h"
+
+void codegen_cache_init();
+void codegen_cache_free();
+int codegen_cache_lookup(uint32_t crc, const uint8_t *orig, size_t orig_size,
+                         struct mem_block_t *block, int *last_pos);
+void codegen_cache_store(uint32_t crc, const uint8_t *orig, size_t orig_size,
+                         const uint8_t *compiled, size_t compiled_size, int last_pos);
+
+#endif /* _CODEGEN_CACHE_H_ */

--- a/src/codegen/codegen.cmake
+++ b/src/codegen/codegen.cmake
@@ -1,6 +1,7 @@
 set(PCEM_PRIVATE_API ${PCEM_PRIVATE_API}
         ${CMAKE_SOURCE_DIR}/includes/private/codegen/codegen_accumulate.h
         ${CMAKE_SOURCE_DIR}/includes/private/codegen/codegen_allocator.h
+        ${CMAKE_SOURCE_DIR}/includes/private/codegen/codegen_cache.h
         ${CMAKE_SOURCE_DIR}/includes/private/codegen/codegen_backend_arm64_defs.h
         ${CMAKE_SOURCE_DIR}/includes/private/codegen/codegen_backend_arm64.h
         ${CMAKE_SOURCE_DIR}/includes/private/codegen/codegen_backend_arm64_ops.h
@@ -52,6 +53,7 @@ set(PCEM_SRC ${PCEM_SRC}
         codegen/codegen.c
         codegen/codegen_accumulate.c
         codegen/codegen_allocator.c
+        codegen/codegen_cache.c
         codegen/codegen_block.c
         codegen/codegen_ir.c
         codegen/codegen_ops.c

--- a/src/codegen/codegen_allocator.c
+++ b/src/codegen/codegen_allocator.c
@@ -10,6 +10,7 @@
 #include "ibm.h"
 #include "codegen.h"
 #include "codegen_allocator.h"
+#include <string.h>
 
 typedef struct mem_block_t {
         uint32_t offset; /*Offset into mem_block_alloc*/
@@ -115,4 +116,50 @@ void codegen_allocator_clean_blocks(struct mem_block_t *block) {
                         break;
         }
 #endif
+}
+
+size_t codeblock_allocator_get_size(struct mem_block_t *block, int last_pos) {
+        size_t size = 0;
+        while (1) {
+                if (block->next) {
+                        size += MEM_BLOCK_SIZE;
+                        block = &mem_blocks[block->next - 1];
+                } else {
+                        size += last_pos;
+                        break;
+                }
+        }
+        return size;
+}
+
+size_t codeblock_allocator_copy(struct mem_block_t *block, int last_pos, uint8_t *dest) {
+        size_t pos = 0;
+        while (1) {
+                uint8_t *src = &mem_block_alloc[block->offset];
+                if (block->next) {
+                        memcpy(dest + pos, src, MEM_BLOCK_SIZE);
+                        pos += MEM_BLOCK_SIZE;
+                        block = &mem_blocks[block->next - 1];
+                } else {
+                        memcpy(dest + pos, src, last_pos);
+                        pos += last_pos;
+                        break;
+                }
+        }
+        return pos;
+}
+
+void codeblock_allocator_write(struct mem_block_t *block, int last_pos, const uint8_t *src) {
+        size_t pos = 0;
+        while (1) {
+                uint8_t *dst = &mem_block_alloc[block->offset];
+                if (block->next) {
+                        memcpy(dst, src + pos, MEM_BLOCK_SIZE);
+                        pos += MEM_BLOCK_SIZE;
+                        block = &mem_blocks[block->next - 1];
+                } else {
+                        memcpy(dst, src + pos, last_pos);
+                        break;
+                }
+        }
 }

--- a/src/codegen/codegen_block.c
+++ b/src/codegen/codegen_block.c
@@ -15,6 +15,8 @@
 #include "codegen_backend.h"
 #include "codegen_ir.h"
 #include "codegen_reg.h"
+#include "codegen_cache.h"
+#include "hdd/minivhd/minivhd_util.h"
 
 uint8_t *block_write_data = NULL;
 
@@ -779,7 +781,37 @@ void codegen_block_end_recompile(codeblock_t *block) {
                 block->flags &= ~CODEBLOCK_STATIC_TOP;
 
         codegen_accumulate_flush(ir_data);
+
+        /*Calculate CRC of original code bytes*/
+        size_t src_size = codegen_endpc - block->pc;
+        uint8_t *src_buf = malloc(src_size);
+        for (size_t i = 0; i < src_size; i++)
+                src_buf[i] = readmembl(block->pc + i);
+        uint32_t crc = mvhd_crc32(src_buf, src_size);
+
+        int cached_pos = 0;
+        int cached_size = codegen_cache_lookup(crc, src_buf, src_size,
+                                               block->head_mem_block, &cached_pos);
+        if (cached_size > 0) {
+                block->compiled_size = cached_size;
+                block->last_pos = cached_pos;
+                block->crc = crc;
+                free(src_buf);
+                codegen_allocator_clean_blocks(block->head_mem_block);
+                return;
+        }
+
         codegen_ir_compile(ir_data, block);
+        block->last_pos = block_pos;
+        block->compiled_size =
+                codeblock_allocator_get_size(block->head_mem_block, block_pos);
+        size_t comp_size = block->compiled_size;
+        uint8_t *comp_buf = malloc(comp_size);
+        codeblock_allocator_copy(block->head_mem_block, block_pos, comp_buf);
+        codegen_cache_store(crc, src_buf, src_size, comp_buf, comp_size, block_pos);
+        block->crc = crc;
+        free(src_buf);
+        free(comp_buf);
 }
 
 void codegen_flush() { return; }

--- a/src/codegen/codegen_cache.c
+++ b/src/codegen/codegen_cache.c
@@ -1,0 +1,71 @@
+#include "codegen_cache.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define CACHE_ENTRIES 64
+
+typedef struct {
+    uint32_t crc;
+    size_t orig_size;
+    uint8_t *orig;
+    uint8_t *compiled;
+    size_t compiled_size;
+    int last_pos;
+    int valid;
+} cache_entry_t;
+
+static cache_entry_t cache[CACHE_ENTRIES];
+static int next_entry = 0;
+
+void codegen_cache_init() {
+    memset(cache, 0, sizeof(cache));
+    next_entry = 0;
+}
+
+void codegen_cache_free() {
+    for (int i = 0; i < CACHE_ENTRIES; i++) {
+        free(cache[i].orig);
+        free(cache[i].compiled);
+        cache[i].orig = NULL;
+        cache[i].compiled = NULL;
+        cache[i].valid = 0;
+    }
+}
+
+int codegen_cache_lookup(uint32_t crc, const uint8_t *orig, size_t orig_size,
+                         struct mem_block_t *block, int *last_pos) {
+    for (int i = 0; i < CACHE_ENTRIES; i++) {
+        cache_entry_t *e = &cache[i];
+        if (e->valid && e->crc == crc && e->orig_size == orig_size &&
+            memcmp(e->orig, orig, orig_size) == 0) {
+            codeblock_allocator_write(block, e->last_pos, e->compiled);
+            if (last_pos)
+                *last_pos = e->last_pos;
+            return (int)e->compiled_size;
+        }
+    }
+    return 0;
+}
+
+void codegen_cache_store(uint32_t crc, const uint8_t *orig, size_t orig_size,
+                         const uint8_t *compiled, size_t compiled_size, int last_pos) {
+    cache_entry_t *e = &cache[next_entry];
+    free(e->orig);
+    free(e->compiled);
+
+    e->crc = crc;
+    e->orig_size = orig_size;
+    e->orig = malloc(orig_size);
+    if (e->orig)
+        memcpy(e->orig, orig, orig_size);
+
+    e->compiled_size = compiled_size;
+    e->compiled = malloc(compiled_size);
+    if (e->compiled)
+        memcpy(e->compiled, compiled, compiled_size);
+
+    e->last_pos = last_pos;
+    e->valid = 1;
+
+    next_entry = (next_entry + 1) % CACHE_ENTRIES;
+}


### PR DESCRIPTION
## Summary
- introduce new code generator cache
- allow copying compiled blocks between recompilations
- expose helper functions in codegen allocator
- store/cache compiled block data on recompilation

## Testing
- `cmake ..` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_684c94416200832c84d7642e3cc5d839