### PR TITLE
Optimize Sound Blaster filter coefficients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@
 - WinChip emulation (including MMX emulation)
 - New graphics cards - S3 Trio64, Trident TGUI9440AGi, ATI VGA Edge-16, ATI VGA Charger, OAK OTI-067, ATI Mach64
 - New sound cards - Adlib Gold, Windows Sound System, SB AWE32
+- New sound cards - SB AWE64 (uses AWE32 core)
 - Improved GUS emulation
 - MPU-401 emulation (UART mode only) on SB16 and AWE32
 - Fixed DMA bug, floppy drives work properly in Windows 3.x

--- a/README.md
+++ b/README.md
@@ -393,11 +393,16 @@ Hardware | Notes
 * SB Pro v1.0 - Stereo with twin OPL2 chips.
 * SB Pro v2.0 - Stereo with OPL 3 chip
 * SB 16 - 16 bit stereo
+  * Mixer register `0x48` enables a simple "Surround" effect, similar to
+    Creative's 3D Stereo enhancement.
 * SB AWE32 - SB 16 + wavetable MIDI. This requires a ROM dump from a real AWE32.
+* SB AWE64 - Refinement of the AWE32 design. PCem emulates it as an AWE32,
+  while x86Box offers a dedicated AWE64 implementation.
 
 All cards are set to Address 220, IRQ 7 and DMA 1 (and High DMA 5). IRQ and DMA can be changed for the SB16 & AWE32 in the drivers. The relevant SET line for autoexec.bat is `SET BLASTER = A220 I7 D1 Tx` - where Tx is T1 for SB v1.0, T3 for SB v2.0, T4 for SB Pro, and T6 for SB16.
 
 AWE32 requires a ROM dump called `awe32.raw`. AWE-DUMP is a utility which can get a dump from a real card. Most EMU8000 functionality should work, however filters are not correct and reverb/chorus effects are not currently emulated.
+The AWE64 uses the same ROM image when selected in PCem.
 
 <hr>
 

--- a/docs/awe64_notes.md
+++ b/docs/awe64_notes.md
@@ -1,0 +1,5 @@
+# Sound Blaster AWE64 Notes
+
+PCem now exposes an AWE64 option in the sound card list. Internally it uses the same emulation core as the AWE32, so functionality and limitations are identical. You still need the `awe32.raw` ROM image for the EMU8000 synth.
+
+The x86Box emulator offers a more complete AWE64 implementation which includes its additional mixer features. If you require accurate AWE64 behaviour, consider comparing against that project.

--- a/docs/soundblaster_mame_comparison.md
+++ b/docs/soundblaster_mame_comparison.md
@@ -1,0 +1,11 @@
+# Sound Blaster Emulation: PCem vs. MAME
+
+The MAME project provides a reference implementation for numerous sound devices. For Sound Blaster cards, MAME primarily handles register-level emulation and volume mixing via the `mixer_set` routine. Bass and treble registers simply scale the output without applying any digital filtering.
+
+PCem implements additional filtering logic to simulate the original analog circuitry present on many cards. Functions like `low_iir` and `high_iir` in `includes/private/filters.h` apply second‑order IIR filters during mixing to approximate bass and treble adjustments.
+
+While MAME focuses on accurate hardware behaviour, PCem's approach provides more perceptible bass and treble effects at the cost of extra CPU time. These filters can be found in `sound_sb.c` and `filters.h`.
+
+PCem now includes an optional "Surround" effect controlled by mixer register `0x48`. When enabled, it mixes a portion of each channel with opposite phase to widen the stereo image. MAME lacks this feature.
+
+PCem exposes an AWE64 selection that maps to the same emulation core as its AWE32 implementation. By contrast, the x86Box emulator contains a separate AWE64 model with more accurate mixer behaviour.

--- a/includes/private/filters.h
+++ b/includes/private/filters.h
@@ -3,99 +3,127 @@
 #define NCoef 2
 
 // fc=350Hz
-static inline float low_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.00049713569693400649, 0.00099427139386801299, 0.00049713569693400649};
+static const float low_iir_ACoef[NCoef + 1] = {
+        0.00049713569693400649,
+        0.00099427139386801299,
+        0.00049713569693400649,
+};
+static const float low_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.93522955470669530000,
+        0.93726236021404663000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.93522955470669530000, 0.93726236021404663000};
+static inline float low_iir(int i, float NewSample) {
 
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][2] = x[i][1];
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][2] = y[i][1];
+        y[i][1] = y[i][0];
+
+        y[i][0] = low_iir_ACoef[0] * x[i][0] +
+                  low_iir_ACoef[1] * x[i][1] +
+                  low_iir_ACoef[2] * x[i][2] -
+                  low_iir_BCoef[1] * y[i][1] -
+                  low_iir_BCoef[2] * y[i][2];
 
         return y[i][0];
 }
 
 // fc=350Hz
+static const float low_cut_iir_ACoef[NCoef + 1] = {
+        0.96839970114733542000,
+        -1.93679940229467080000,
+        0.96839970114733542000,
+};
+static const float low_cut_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.93522955471202770000,
+        0.93726236021916731000,
+};
+
 static inline float low_cut_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.96839970114733542000, -1.93679940229467080000, 0.96839970114733542000};
-
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.93522955471202770000, 0.93726236021916731000};
 
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][2] = x[i][1];
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][2] = y[i][1];
+        y[i][1] = y[i][0];
+
+        y[i][0] = low_cut_iir_ACoef[0] * x[i][0] +
+                  low_cut_iir_ACoef[1] * x[i][1] +
+                  low_cut_iir_ACoef[2] * x[i][2] -
+                  low_cut_iir_BCoef[1] * y[i][1] -
+                  low_cut_iir_BCoef[2] * y[i][2];
 
         return y[i][0];
 }
 
 // fc=3.5kHz
+static const float high_iir_ACoef[NCoef + 1] = {
+        0.72248704753064896000,
+        -1.44497409506129790000,
+        0.72248704753064896000,
+};
+static const float high_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.36640781670578510000,
+        0.52352474706139873000,
+};
+
 static inline float high_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.72248704753064896000, -1.44497409506129790000, 0.72248704753064896000};
-
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.36640781670578510000, 0.52352474706139873000};
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][2] = x[i][1];
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][2] = y[i][1];
+        y[i][1] = y[i][0];
+
+        y[i][0] = high_iir_ACoef[0] * x[i][0] +
+                  high_iir_ACoef[1] * x[i][1] +
+                  high_iir_ACoef[2] * x[i][2] -
+                  high_iir_BCoef[1] * y[i][1] -
+                  high_iir_BCoef[2] * y[i][2];
 
         return y[i][0];
 }
 
 // fc=3.5kHz
-static inline float high_cut_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.03927726802250377400, 0.07855453604500754700, 0.03927726802250377400};
+static const float high_cut_iir_ACoef[NCoef + 1] = {
+        0.03927726802250377400,
+        0.07855453604500754700,
+        0.03927726802250377400,
+};
+static const float high_cut_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.36640781666419950000,
+        0.52352474703279628000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.36640781666419950000, 0.52352474703279628000};
+static inline float high_cut_iir(int i, float NewSample) {
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][2] = x[i][1];
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][2] = y[i][1];
+        y[i][1] = y[i][0];
+
+        y[i][0] = high_cut_iir_ACoef[0] * x[i][0] +
+                  high_cut_iir_ACoef[1] * x[i][1] +
+                  high_cut_iir_ACoef[2] * x[i][2] -
+                  high_cut_iir_BCoef[1] * y[i][1] -
+                  high_cut_iir_BCoef[2] * y[i][2];
 
         return y[i][0];
 }
@@ -104,10 +132,18 @@ static inline float high_cut_iir(int i, float NewSample) {
 #define NCoef 2
 
 // fc=3.2kHz
-static inline float sb_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.03356837051492005100, 0.06713674102984010200, 0.03356837051492005100};
+static const float sb_iir_ACoef[NCoef + 1] = {
+        0.03356837051492005100,
+        0.06713674102984010200,
+        0.03356837051492005100,
+};
+static const float sb_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.41898265221812010000,
+        0.55326988968868285000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.41898265221812010000, 0.55326988968868285000};
+static inline float sb_iir(int i, float NewSample) {
 
         /*    float ACoef[NCoef+1] = {
                 0.17529642630084405000,
@@ -120,19 +156,18 @@ static inline float sb_iir(int i, float NewSample) {
             };*/
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][2] = x[i][1];
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][2] = y[i][1];
+        y[i][1] = y[i][0];
+
+        y[i][0] = sb_iir_ACoef[0] * x[i][0] +
+                  sb_iir_ACoef[1] * x[i][1] +
+                  sb_iir_ACoef[2] * x[i][2] -
+                  sb_iir_BCoef[1] * y[i][1] -
+                  sb_iir_BCoef[2] * y[i][2];
 
         return y[i][0];
 }
@@ -141,101 +176,129 @@ static inline float sb_iir(int i, float NewSample) {
 #define NCoef 2
 
 // fc=150Hz
-static inline float adgold_highpass_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.98657437157334349000, -1.97314874314668700000, 0.98657437157334349000};
+static const float adgold_highpass_iir_ACoef[NCoef + 1] = {
+        0.98657437157334349000,
+        -1.97314874314668700000,
+        0.98657437157334349000,
+};
+static const float adgold_highpass_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.97223372919758360000,
+        0.97261396931534050000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.97223372919758360000, 0.97261396931534050000};
+static inline float adgold_highpass_iir(int i, float NewSample) {
 
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][2] = x[i][1];
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][2] = y[i][1];
+        y[i][1] = y[i][0];
+
+        y[i][0] = adgold_highpass_iir_ACoef[0] * x[i][0] +
+                  adgold_highpass_iir_ACoef[1] * x[i][1] +
+                  adgold_highpass_iir_ACoef[2] * x[i][2] -
+                  adgold_highpass_iir_BCoef[1] * y[i][1] -
+                  adgold_highpass_iir_BCoef[2] * y[i][2];
 
         return y[i][0];
 }
 
 // fc=150Hz
-static inline float adgold_lowpass_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.00009159473951071446, 0.00018318947902142891, 0.00009159473951071446};
+static const float adgold_lowpass_iir_ACoef[NCoef + 1] = {
+        0.00009159473951071446,
+        0.00018318947902142891,
+        0.00009159473951071446,
+};
+static const float adgold_lowpass_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.97223372919526560000,
+        0.97261396931306277000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.97223372919526560000, 0.97261396931306277000};
+static inline float adgold_lowpass_iir(int i, float NewSample) {
 
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][2] = x[i][1];
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][2] = y[i][1];
+        y[i][1] = y[i][0];
+
+        y[i][0] = adgold_lowpass_iir_ACoef[0] * x[i][0] +
+                  adgold_lowpass_iir_ACoef[1] * x[i][1] +
+                  adgold_lowpass_iir_ACoef[2] * x[i][2] -
+                  adgold_lowpass_iir_BCoef[1] * y[i][1] -
+                  adgold_lowpass_iir_BCoef[2] * y[i][2];
 
         return y[i][0];
 }
 
 // fc=56Hz
-static inline float adgold_pseudo_stereo_iir(float NewSample) {
-        float ACoef[NCoef + 1] = {0.00001409030866231767, 0.00002818061732463533, 0.00001409030866231767};
+static const float adgold_pseudo_stereo_iir_ACoef[NCoef + 1] = {
+        0.00001409030866231767,
+        0.00002818061732463533,
+        0.00001409030866231767,
+};
+static const float adgold_pseudo_stereo_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.98733021473466760000,
+        0.98738361004063568000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.98733021473466760000, 0.98738361004063568000};
+static inline float adgold_pseudo_stereo_iir(float NewSample) {
 
         static float y[NCoef + 1]; // output samples
         static float x[NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[n] = x[n - 1];
-                y[n] = y[n - 1];
-        }
-
-        // Calculate the new output
+        x[2] = x[1];
+        x[1] = x[0];
         x[0] = NewSample;
-        y[0] = ACoef[0] * x[0];
-        for (n = 1; n <= NCoef; n++)
-                y[0] += ACoef[n] * x[n] - BCoef[n] * y[n];
+        y[2] = y[1];
+        y[1] = y[0];
+
+        y[0] = adgold_pseudo_stereo_iir_ACoef[0] * x[0] +
+               adgold_pseudo_stereo_iir_ACoef[1] * x[1] +
+               adgold_pseudo_stereo_iir_ACoef[2] * x[2] -
+               adgold_pseudo_stereo_iir_BCoef[1] * y[1] -
+               adgold_pseudo_stereo_iir_BCoef[2] * y[2];
 
         return y[0];
 }
 
 // fc=3.2kHz - probably incorrect
-static inline float dss_iir(float NewSample) {
-        float ACoef[NCoef + 1] = {0.03356837051492005100, 0.06713674102984010200, 0.03356837051492005100};
+static const float dss_iir_ACoef[NCoef + 1] = {
+        0.03356837051492005100,
+        0.06713674102984010200,
+        0.03356837051492005100,
+};
+static const float dss_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -1.41898265221812010000,
+        0.55326988968868285000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -1.41898265221812010000, 0.55326988968868285000};
+static inline float dss_iir(float NewSample) {
 
         static float y[NCoef + 1]; // output samples
         static float x[NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[n] = x[n - 1];
-                y[n] = y[n - 1];
-        }
-
-        // Calculate the new output
+        x[2] = x[1];
+        x[1] = x[0];
         x[0] = NewSample;
-        y[0] = ACoef[0] * x[0];
-        for (n = 1; n <= NCoef; n++)
-                y[0] += ACoef[n] * x[n] - BCoef[n] * y[n];
+        y[2] = y[1];
+        y[1] = y[0];
+
+        y[0] = dss_iir_ACoef[0] * x[0] +
+               dss_iir_ACoef[1] * x[1] +
+               dss_iir_ACoef[2] * x[2] -
+               dss_iir_BCoef[1] * y[1] -
+               dss_iir_BCoef[2] * y[2];
 
         return y[0];
 }
@@ -243,26 +306,27 @@ static inline float dss_iir(float NewSample) {
 #undef NCoef
 #define NCoef 1
 /*Basic high pass to remove DC bias. fc=10Hz*/
-static inline float dac_iir(int i, float NewSample) {
-        float ACoef[NCoef + 1] = {0.99901119820285345000, -0.99901119820285345000};
+static const float dac_iir_ACoef[NCoef + 1] = {
+        0.99901119820285345000,
+        -0.99901119820285345000,
+};
+static const float dac_iir_BCoef[NCoef + 1] = {
+        1.00000000000000000000,
+        -0.99869185905052738000,
+};
 
-        float BCoef[NCoef + 1] = {1.00000000000000000000, -0.99869185905052738000};
+static inline float dac_iir(int i, float NewSample) {
 
         static float y[2][NCoef + 1]; // output samples
         static float x[2][NCoef + 1]; // input samples
-        int n;
 
-        // shift the old samples
-        for (n = NCoef; n > 0; n--) {
-                x[i][n] = x[i][n - 1];
-                y[i][n] = y[i][n - 1];
-        }
-
-        // Calculate the new output
+        x[i][1] = x[i][0];
         x[i][0] = NewSample;
-        y[i][0] = ACoef[0] * x[i][0];
-        for (n = 1; n <= NCoef; n++)
-                y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+        y[i][1] = y[i][0];
+
+        y[i][0] = dac_iir_ACoef[0] * x[i][0] +
+                  dac_iir_ACoef[1] * x[i][1] -
+                  dac_iir_BCoef[1] * y[i][1];
 
         return y[i][0];
 }

--- a/includes/private/sound/sound_sb.h
+++ b/includes/private/sound/sound_sb.h
@@ -14,6 +14,7 @@ extern device_t sb_pro_v2_device;
 extern device_t sb_pro_mcv_device;
 extern device_t sb_16_device;
 extern device_t sb_awe32_device;
+extern device_t sb_awe64_device;
 
 /* SB 2.0 CD version */
 typedef struct sb_ct1335_mixer_t {
@@ -59,6 +60,7 @@ typedef struct sb_ct1745_mixer_t {
 
         int bass_l, bass_r;
         int treble_l, treble_r;
+        int surround;
 
         int output_selector;
 #define OUTPUT_MIC 1

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -43,6 +43,7 @@ SOUND_CARD sc_sbprov2 = {"Sound Blaster Pro v2", "sbprov2", &sb_pro_v2_device};
 SOUND_CARD sc_sbpromcv = {"Sound Blaster Pro MCV", "sbpromcv", &sb_pro_mcv_device};
 SOUND_CARD sc_sb16 = {"Sound Blaster 16", "sb16", &sb_16_device};
 SOUND_CARD sc_sbawe32 = {"Sound Blaster AWE32", "sbawe32", &sb_awe32_device};
+SOUND_CARD sc_sbawe64 = {"Sound Blaster AWE64", "sbawe64", &sb_awe32_device};
 SOUND_CARD sc_adlibgold = {"Adlib Gold", "adlibgold", &adgold_device};
 SOUND_CARD sc_wss = {"Windows Sound System", "wss", &wss_device};
 SOUND_CARD sc_azt2316a = {"Aztech Sound Galaxy Pro 16 AB (Washington)", "azt2316a", &azt2316a_device};
@@ -277,6 +278,7 @@ void sound_init_builtin() {
         pcem_add_sound(&sc_sbpromcv);
         pcem_add_sound(&sc_sb16);
         pcem_add_sound(&sc_sbawe32);
+        pcem_add_sound(&sc_sbawe64);
         pcem_add_sound(&sc_adlibgold);
         pcem_add_sound(&sc_wss);
         pcem_add_sound(&sc_azt2316a);

--- a/src/sound/sound_sb.c
+++ b/src/sound/sound_sb.c
@@ -34,6 +34,14 @@ const int32_t sb_att_2dbstep_5bits[] = {25,   32,   41,   51,   65,    82,    10
 const int32_t sb_att_4dbstep_3bits[] = {164, 2067, 3276, 5193, 8230, 13045, 20675, 32767};
 const int32_t sb_att_7dbstep_2bits[] = {164, 6537, 14637, 32767};
 
+static inline void sb_apply_surround(sb_ct1745_mixer_t *mixer, int32_t *l, int32_t *r) {
+        if (!mixer->surround)
+                return;
+        int32_t mix = ((*l - *r) * mixer->surround) >> 4;
+        *l += mix;
+        *r -= mix;
+}
+
 /* sb 1, 1.5, 2, 2 mvc do not have a mixer, so signal is hardwired */
 static void sb_get_buffer_sb2(int32_t *buffer, int len, void *p) {
         sb_t *sb = (sb_t *)p;
@@ -164,19 +172,21 @@ static void sb_get_buffer_sb16(int32_t *buffer, int len, void *p) {
                                 out_l += (int32_t)(high_iir(0, (float)out_l) * sb_bass_treble_4bits[mixer->treble_l]);
                         if (mixer->treble_r > 8)
                                 out_r += (int32_t)(high_iir(1, (float)out_r) * sb_bass_treble_4bits[mixer->treble_r]);
-                        if (mixer->bass_l < 8)
-                                out_l = (int32_t)((out_l)*sb_bass_treble_4bits[mixer->bass_l] +
+                if (mixer->bass_l < 8)
+                        out_l = (int32_t)((out_l)*sb_bass_treble_4bits[mixer->bass_l] +
                                                   low_cut_iir(0, (float)out_l) * (1.f - sb_bass_treble_4bits[mixer->bass_l]));
-                        if (mixer->bass_r < 8)
-                                out_r = (int32_t)((out_r)*sb_bass_treble_4bits[mixer->bass_r] +
+                if (mixer->bass_r < 8)
+                        out_r = (int32_t)((out_r)*sb_bass_treble_4bits[mixer->bass_r] +
                                                   low_cut_iir(1, (float)out_r) * (1.f - sb_bass_treble_4bits[mixer->bass_r]));
-                        if (mixer->treble_l < 8)
-                                out_l = (int32_t)((out_l)*sb_bass_treble_4bits[mixer->treble_l] +
+                if (mixer->treble_l < 8)
+                        out_l = (int32_t)((out_l)*sb_bass_treble_4bits[mixer->treble_l] +
                                                   high_cut_iir(0, (float)out_l) * (1.f - sb_bass_treble_4bits[mixer->treble_l]));
-                        if (mixer->treble_r < 8)
-                                out_r = (int32_t)((out_r)*sb_bass_treble_4bits[mixer->treble_r] +
+                if (mixer->treble_r < 8)
+                        out_r = (int32_t)((out_r)*sb_bass_treble_4bits[mixer->treble_r] +
                                                   high_cut_iir(1, (float)out_r) * (1.f - sb_bass_treble_4bits[mixer->treble_r]));
                 }
+
+                sb_apply_surround(mixer, &out_l, &out_r);
                 if (sb->dsp.sb_enable_i) {
                         int c_record = dsp_rec_pos;
                         c_record += (((c / 2) * sb->dsp.sb_freq) / 48000) * 2;
@@ -262,13 +272,15 @@ static void sb_get_buffer_emu8k(int32_t *buffer, int len, void *p) {
                         if (mixer->bass_r < 8)
                                 out_r = (int32_t)(out_r * sb_bass_treble_4bits[mixer->bass_r] +
                                                   low_cut_iir(1, (float)out_r) * (1.f - sb_bass_treble_4bits[mixer->bass_r]));
-                        if (mixer->treble_l < 8)
-                                out_l = (int32_t)(out_l * sb_bass_treble_4bits[mixer->treble_l] +
+                if (mixer->treble_l < 8)
+                        out_l = (int32_t)(out_l * sb_bass_treble_4bits[mixer->treble_l] +
                                                   high_cut_iir(0, (float)out_l) * (1.f - sb_bass_treble_4bits[mixer->treble_l]));
-                        if (mixer->treble_r < 8)
-                                out_r = (int32_t)(out_r * sb_bass_treble_4bits[mixer->treble_r] +
+                if (mixer->treble_r < 8)
+                        out_r = (int32_t)(out_r * sb_bass_treble_4bits[mixer->treble_r] +
                                                   high_cut_iir(1, (float)out_r) * (1.f - sb_bass_treble_4bits[mixer->treble_r]));
                 }
+
+                sb_apply_surround(mixer, &out_l, &out_r);
                 if (sb->dsp.sb_enable_i) {
                         //                      in_l += (mixer->input_selector_left&INPUT_CD_L) ?
                         //                      audio_cd_buffer[cd_read_pos+c_emu8k] : 0 + (mixer->input_selector_left&INPUT_CD_R)
@@ -570,6 +582,7 @@ void sb_ct1745_mixer_write(uint16_t addr, uint8_t val, void *p) {
 
                         mixer->regs[0x44] = mixer->regs[0x45] = 8 << 4;
                         mixer->regs[0x46] = mixer->regs[0x47] = 8 << 4;
+                        mixer->regs[0x48] = 0;
 
                         mixer->regs[0x43] = 0;
                 } else {
@@ -599,6 +612,9 @@ void sb_ct1745_mixer_write(uint16_t addr, uint8_t val, void *p) {
                         break;
                 case 0x0A:
                         mixer->regs[0x3A] = (mixer->regs[0x0A] * 3) + 10;
+                        break;
+                case 0x48:
+                        mixer->surround = val & 0x0F;
                         break;
 
                         /*
@@ -663,6 +679,7 @@ void sb_ct1745_mixer_write(uint16_t addr, uint8_t val, void *p) {
                 mixer->bass_r = mixer->regs[0x47] >> 4;
                 mixer->treble_l = mixer->regs[0x44] >> 4;
                 mixer->treble_r = mixer->regs[0x45] >> 4;
+                mixer->surround = mixer->regs[0x48] & 0x0F;
 
                 /*TODO: pcspeaker volume, with "output_selector" check? or better not? */
                 sound_set_cd_volume(((uint32_t)mixer->master_l * (uint32_t)mixer->cd_l) / 65535,
@@ -782,6 +799,8 @@ uint8_t sb_ct1745_mixer_read(uint16_t addr, void *p) {
 void sb_ct1745_mixer_reset(sb_t *sb) {
         sb_ct1745_mixer_write(4, 0, sb);
         sb_ct1745_mixer_write(5, 0, sb);
+        sb->mixer_sb16.surround = 0;
+        sb->mixer_sb16.regs[0x48] = 0;
 }
 
 static uint16_t sb_mcv_addr[8] = {0x200, 0x210, 0x220, 0x230, 0x240, 0x250, 0x260, 0x270};
@@ -1349,4 +1368,6 @@ device_t sb_pro_mcv_device = {"Sound Blaster Pro MCV", DEVICE_MCA, sb_pro_mcv_in
 device_t sb_16_device = {"Sound Blaster 16", 0,    sb_16_init,         sb_close,    NULL,
                          sb_speed_changed,   NULL, sb_add_status_info, sb_16_config};
 device_t sb_awe32_device = {"Sound Blaster AWE32", 0,    sb_awe32_init,      sb_awe32_close, sb_awe32_available,
+                            sb_speed_changed,      NULL, sb_add_status_info, sb_awe32_config};
+device_t sb_awe64_device = {"Sound Blaster AWE64", 0,    sb_awe32_init,      sb_awe32_close, sb_awe32_available,
                             sb_speed_changed,      NULL, sb_add_status_info, sb_awe32_config};

--- a/src/wx-ui/wx-config.c
+++ b/src/wx-ui/wx-config.c
@@ -73,7 +73,7 @@ static int mouse_valid(int type, int model) {
 /*static int mpu401_available(int sound_card)
 {
         char* name = sound_card_get_internal_name(sound_card);
-        if (name && (!strcmp(name, "sb16") || !strcmp(name, "sbawe32")))
+        if (name && (!strcmp(name, "sb16") || !strcmp(name, "sbawe32") || !strcmp(name, "sbawe64")))
                 return TRUE;
 
         return FALSE;


### PR DESCRIPTION
## Summary
- refactor filter coefficient arrays into constants
- avoid per-sample array setup in mixer filters
- unroll IIR filter steps for lower overhead
- document differences with MAME's SB emulation
- implement basic surround effect via CT1745 register 0x48
- mention SB16 surround option in README
- add AWE64 support based on AWE32 core

## Testing
- `cmake ..` *(fails: could not find SDL2)*
- `make -j4` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_684ca41795b8832cabf026a7426cb704