### PR TITLE
Implement basic CT1745 detection

### DIFF
--- a/includes/private/sound/sound_sb.h
+++ b/includes/private/sound/sound_sb.h
@@ -118,4 +118,6 @@ void sb_close(void *p);
 void sb_speed_changed(void *p);
 void sb_add_status_info(char *s, int max_len, void *p);
 
+int sb_ct1745_mixer_detect(sb_t *sb);
+
 #endif /* SOUND_SB_H */

--- a/src/sound/sound_sb.c
+++ b/src/sound/sound_sb.c
@@ -810,6 +810,33 @@ void sb_ct1745_mixer_reset(sb_t *sb) {
         sb->mixer_sb16.regs[0x90] = 0;
 }
 
+int sb_ct1745_mixer_detect(sb_t *sb) {
+        sb_ct1745_mixer_t *mixer = &sb->mixer_sb16;
+
+        uint8_t saved_index = mixer->index;
+        uint8_t saved_83 = mixer->regs[0x83];
+
+        /* emulate CSP.SYS detection sequence */
+        sb_ct1745_mixer_write(0, 0, sb);
+        sb_ct1745_mixer_write(0xfc, 0xfc, sb); /* set mode register */
+
+        uint8_t test1 = sb_ct1745_mixer_read(0x83, sb);
+        sb_ct1745_mixer_write(0x83, ~test1, sb);
+        uint8_t test2 = sb_ct1745_mixer_read(0x83, sb);
+
+        int detected = (test2 == (uint8_t)(test1 ^ 0xff));
+        if (detected) {
+                sb_ct1745_mixer_write(0x83, test1, sb);
+                detected = (sb_ct1745_mixer_read(0x83, sb) == test1);
+        }
+
+        sb_ct1745_mixer_write(0xfc, 0, sb); /* restore mode register */
+        sb_ct1745_mixer_write(0x83, saved_83, sb);
+        mixer->index = saved_index;
+
+        return detected;
+}
+
 static uint16_t sb_mcv_addr[8] = {0x200, 0x210, 0x220, 0x230, 0x240, 0x250, 0x260, 0x270};
 
 uint8_t sb_mcv_read(int port, void *p) {
@@ -1084,6 +1111,7 @@ void *sb_16_init() {
         sb_dsp_setaddr(&sb->dsp, addr);
         // TODO: irq and dma options too?
         sb_ct1745_mixer_reset(sb);
+        sb_ct1745_mixer_detect(sb);
         io_sethandler(addr, 0x0004, opl3_read, NULL, NULL, opl3_write, NULL, NULL, &sb->opl);
         io_sethandler(addr + 8, 0x0002, opl3_read, NULL, NULL, opl3_write, NULL, NULL, &sb->opl);
         io_sethandler(0x0388, 0x0004, opl3_read, NULL, NULL, opl3_write, NULL, NULL, &sb->opl);
@@ -1109,6 +1137,7 @@ void *sb_awe32_init() {
         sb_dsp_setaddr(&sb->dsp, addr);
         // TODO: irq and dma options too?
         sb_ct1745_mixer_reset(sb);
+        sb_ct1745_mixer_detect(sb);
         io_sethandler(addr, 0x0004, opl3_read, NULL, NULL, opl3_write, NULL, NULL, &sb->opl);
         io_sethandler(addr + 8, 0x0002, opl3_read, NULL, NULL, opl3_write, NULL, NULL, &sb->opl);
         io_sethandler(0x0388, 0x0004, opl3_read, NULL, NULL, opl3_write, NULL, NULL, &sb->opl);


### PR DESCRIPTION
## Summary
- add `sb_ct1745_mixer_detect` prototype
- implement a basic CT1745 mixer detection routine
- call detection during SB16/AWE32 initialisation

## Testing
- `cmake ..` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_684d5381ce10832c98a94668958947c9