### PR TITLE
Fix Windows build by adjusting WHPX attributes

### DIFF
--- a/src/whpx.c
+++ b/src/whpx.c
@@ -8,7 +8,13 @@
 #include <WinHvPlatform.h>
 #include <WinHvEmulation.h>
 
+#ifdef __MINGW32__
+/* MinGW headers expose segment attributes directly as a UINT16 field */
+#define SEGATTR(seg) ((seg).Attributes)
+#else
+/* Windows SDK headers wrap the attributes inside a union */
 #define SEGATTR(seg) ((seg).Attributes.AsUINT16)
+#endif
 
 static WHV_PARTITION_HANDLE whpx_partition = NULL;
 static UINT32 whpx_vcpu_id = 0;

--- a/tools/check-whpx.c
+++ b/tools/check-whpx.c
@@ -3,7 +3,13 @@
 #include <windows.h>
 #include <WinHvPlatform.h>
 #include <WinHvEmulation.h>
+#ifdef __MINGW32__
+/* MinGW headers expose segment attributes directly as a UINT16 field */
+#define SEGATTR(seg) ((seg).Attributes)
+#else
+/* Windows SDK headers wrap the attributes inside a union */
 #define SEGATTR(seg) ((seg).Attributes.AsUINT16)
+#endif
 #endif
 
 int main(void)


### PR DESCRIPTION
## Summary
- fix WHPX segment attribute macro for MinGW headers

## Testing
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_686ad05c6d00832c801074832427bb99