### PR TITLE
Fix memory alignment for WHPX

### DIFF
--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -8,6 +8,9 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(_WIN32) && defined(USE_WHPX)
+#include <windows.h>
+#endif
 #include "ibm.h"
 
 #include "config.h"
@@ -1340,8 +1343,14 @@ void mem_init() {
 void mem_alloc() {
         int c;
 
+#if defined(_WIN32) && defined(USE_WHPX)
+        if (ram)
+                VirtualFree(ram, 0, MEM_RELEASE);
+        ram = VirtualAlloc(NULL, mem_size * 1024, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+#else
         free(ram);
         ram = malloc(mem_size * 1024);
+#endif
         memset(ram, 0, mem_size * 1024);
 
         free(byte_dirty_mask);

--- a/src/whpx.c
+++ b/src/whpx.c
@@ -8,7 +8,13 @@
 #include <WinHvPlatform.h>
 #include <WinHvEmulation.h>
 
+#ifdef __MINGW32__
+/* MinGW headers expose segment attributes directly as a UINT16 field */
+#define SEGATTR(seg) ((seg).Attributes)
+#else
+/* Windows SDK headers wrap the attributes inside a union */
 #define SEGATTR(seg) ((seg).Attributes.AsUINT16)
+#endif
 
 static WHV_PARTITION_HANDLE whpx_partition = NULL;
 static UINT32 whpx_vcpu_id = 0;

--- a/tools/check-whpx.c
+++ b/tools/check-whpx.c
@@ -3,7 +3,13 @@
 #include <windows.h>
 #include <WinHvPlatform.h>
 #include <WinHvEmulation.h>
+#ifdef __MINGW32__
+/* MinGW headers expose segment attributes directly as a UINT16 field */
+#define SEGATTR(seg) ((seg).Attributes)
+#else
+/* Windows SDK headers wrap the attributes inside a union */
 #define SEGATTR(seg) ((seg).Attributes.AsUINT16)
+#endif
 #endif
 
 int main(void)


### PR DESCRIPTION
## Summary
- align guest RAM allocation on Windows when using WHPX

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..` *(fails: Could NOT find wxWidgets)*
- `ninja` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ad05c6d00832c801074832427bb99