### PR TITLE
Add extra WHPX debug logging

### DIFF
--- a/src/whpx.c
+++ b/src/whpx.c
@@ -188,6 +188,8 @@ int whpx_vcpu_create(void)
         return -1;
     if (whpx_vcpu_created)
         whpx_vcpu_destroy();
+    pclog("Creating vCPU: partition=%p id=%u flags=0\n",
+          whpx_partition, whpx_vcpu_id);
     HRESULT hr = WHvCreateVirtualProcessor(whpx_partition, whpx_vcpu_id, 0);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvCreateVirtualProcessor", hr);
@@ -206,6 +208,7 @@ int whpx_map_memory(void *mem, size_t size)
 {
     if (!whpx_partition)
         return -1;
+    pclog("Mapping memory: addr=%p size=%zu\n", mem, size);
     whpx_ram = mem;
     whpx_ram_size = size;
     HRESULT hr = WHvMapGpaRange(whpx_partition, mem, 0, size,


### PR DESCRIPTION
## Summary
- add a log message when creating a WHPX vCPU
- log memory address and size when mapping memory

## Testing
- `cmake -G "Ninja" -DMSYS=TRUE -DUSE_WHPX=ON -DCMAKE_BUILD_TYPE=Release -S . -B build` *(fails: SDL2Config.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af2e0b054832ca585a4beb04c029e