### PR TITLE
Improve WHPX reinitialization

### DIFF
--- a/src/cpu_backend.c
+++ b/src/cpu_backend.c
@@ -50,11 +50,20 @@ void cpu_backend_exec(int cycle_count) {
 void cpu_backend_memory_init(void) {
 #ifdef USE_WHPX
         if (cpu_backend == CPU_BACKEND_WHPX) {
+                whpx_vcpu_destroy();
+                whpx_deinit();
+                if (whpx_init() != 0) {
+                        pclog("whpx: reinitialization failed, falling back to interpreter\n");
+                        cpu_backend = CPU_BACKEND_RECOMP;
+                        return;
+                }
+
                 if (whpx_map_memory(ram, mem_size * 1024) != 0) {
                         pclog("whpx: memory mapping failed, falling back to interpreter\n");
                         cpu_backend = CPU_BACKEND_RECOMP;
                         return;
                 }
+
                 if (whpx_vcpu_create() != 0) {
                         pclog("whpx: vcpu creation failed, falling back to interpreter\n");
                         cpu_backend = CPU_BACKEND_RECOMP;

--- a/src/whpx.c
+++ b/src/whpx.c
@@ -2,6 +2,7 @@
 #include "whpx.h"
 #include "x86.h"
 #include "ibm.h"
+#include <stdint.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -101,6 +102,9 @@ static int whpx_vcpu_created = 0;
 
 int whpx_init(void)
 {
+#if UINTPTR_MAX != 0xffffffffffffffffULL
+    pclog("whpx: 32-bit build detected; WHPX requires a 64-bit executable\n");
+#endif
     HRESULT hr;
 #ifdef _WIN32
     /* WHvGetCapability expects a BOOL buffer. Using the 1-byte BOOLEAN
@@ -188,11 +192,18 @@ int whpx_vcpu_create(void)
         return -1;
     if (whpx_vcpu_created)
         whpx_vcpu_destroy();
+    pclog("Creating vCPU: partition=%p id=%u flags=0\n",
+          whpx_partition, whpx_vcpu_id);
     HRESULT hr = WHvCreateVirtualProcessor(whpx_partition, whpx_vcpu_id, 0);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvCreateVirtualProcessor", hr);
 #ifdef _WIN32
         whpx_log_hresult("WHvCreateVirtualProcessor failed", hr);
+#ifdef E_INVALIDARG
+        if (hr == E_INVALIDARG)
+            pclog("whpx: invalid arguments when creating the vCPU. "
+                  "Ensure PCem is built for 64-bit and RAM is page aligned.\n");
+#endif
 #else
         pclog("whpx: WHvCreateVirtualProcessor failed: 0x%lx\n", hr);
 #endif
@@ -206,6 +217,17 @@ int whpx_map_memory(void *mem, size_t size)
 {
     if (!whpx_partition)
         return -1;
+    uintptr_t addr = (uintptr_t)mem;
+    pclog("Mapping memory: addr=%p size=%zu (addr mod 4K=0x%lx size mod 4K=0x%lx)\n",
+          mem, size, addr & 0xfff, (unsigned long)size & 0xfff);
+
+    if (whpx_ram && whpx_ram_size) {
+        pclog("Unmapping previous memory range size=%zu\n", whpx_ram_size);
+        HRESULT hr2 = WHvUnmapGpaRange(whpx_partition, 0, whpx_ram_size);
+        if (FAILED(hr2))
+            whpx_log_hresult("WHvUnmapGpaRange", hr2);
+    }
+
     whpx_ram = mem;
     whpx_ram_size = size;
     HRESULT hr = WHvMapGpaRange(whpx_partition, mem, 0, size,


### PR DESCRIPTION
## Summary
- destroy the previous WHPX vCPU before remapping RAM
- unmap old memory ranges when `whpx_map_memory` is called again
- fully recreate the WHPX partition whenever PCem remaps guest RAM

## Testing
- `cmake -G "Ninja" -DMSYS=TRUE -DUSE_WHPX=ON -DCMAKE_BUILD_TYPE=Release -S . -B build` *(fails: SDL2Config.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af2e0b054832ca585a4beb04c029e