### PR TITLE
Avoid dynarec while WHPX is active

### DIFF
--- a/src/cpu_backend.c
+++ b/src/cpu_backend.c
@@ -36,7 +36,14 @@ void cpu_backend_exec(int cycle_count) {
                         return; /* HALT */
                 if (rc < 0)
                         cpu_backend = CPU_BACKEND_RECOMP;
-                /* rc == 0 falls through to interpreter */
+                /* Unhandled exits are emulated using the interpreter */
+                if (rc >= 0) {
+                        if (is386 || AT)
+                                exec386(cycle_count);
+                        else
+                                execx86(cycle_count);
+                        return;
+                }
         }
 #endif
         if (is386) {


### PR DESCRIPTION
## Summary
- avoid running dynarec when the WHPX backend is active

## Testing
- `cmake ..` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_686d62b65564832c806a721317efb388