### PR TITLE
Simplify WHPX error logging

### DIFF
--- a/includes/private/whpx.h
+++ b/includes/private/whpx.h
@@ -12,6 +12,7 @@ int whpx_vcpu_create(void);
 void whpx_vcpu_destroy(void);
 int whpx_vcpu_run(void);
 int whpx_map_memory(void *mem, size_t size);
+int whpx_map_rom(const void *mem, unsigned long long gpa, size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -22,6 +22,10 @@
 #include "x86_ops.h"
 #include "codegen.h"
 #include "xi8088.h"
+#ifdef USE_WHPX
+#include "cpu_backend.h"
+#include "whpx.h"
+#endif
 
 page_t *pages;
 page_t **page_lookup;
@@ -41,6 +45,16 @@ mem_mapping_t bios_high_mapping[9];
 static mem_mapping_t romext_mapping;
 
 static uint8_t ff_array[0x1000];
+
+#ifdef USE_WHPX
+#define WHPX_MAP_ROM(off, addr) \
+    do { \
+        if (cpu_backend == CPU_BACKEND_WHPX) \
+            whpx_map_rom(rom + ((off) & biosmask), (addr), 0x4000); \
+    } while (0)
+#else
+#define WHPX_MAP_ROM(off, addr) do { } while (0)
+#endif
 
 int mem_size;
 uint32_t biosmask;
@@ -1240,53 +1254,71 @@ void mem_add_bios() {
                 mem_mapping_add(&bios_mapping[0], 0xe0000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                                 mem_write_nullw, mem_write_nulll, rom + (0x20000 & biosmask),
                                 MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+                WHPX_MAP_ROM(0x20000, 0xe0000);
                 mem_mapping_add(&bios_mapping[1], 0xe4000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                                 mem_write_nullw, mem_write_nulll, rom + (0x24000 & biosmask),
                                 MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+                WHPX_MAP_ROM(0x24000, 0xe4000);
                 mem_mapping_add(&bios_mapping[2], 0xe8000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                                 mem_write_nullw, mem_write_nulll, rom + (0x28000 & biosmask),
                                 MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+                WHPX_MAP_ROM(0x28000, 0xe8000);
                 mem_mapping_add(&bios_mapping[3], 0xec000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                                 mem_write_nullw, mem_write_nulll, rom + (0x2c000 & biosmask),
                                 MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+                WHPX_MAP_ROM(0x2c000, 0xec000);
         }
         mem_mapping_add(&bios_mapping[4], 0xf0000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                         mem_write_nullw, mem_write_nulll, rom + (0x30000 & biosmask), MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x30000, 0xf0000);
         mem_mapping_add(&bios_mapping[5], 0xf4000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                         mem_write_nullw, mem_write_nulll, rom + (0x34000 & biosmask), MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x34000, 0xf4000);
         mem_mapping_add(&bios_mapping[6], 0xf8000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                         mem_write_nullw, mem_write_nulll, rom + (0x38000 & biosmask), MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x38000, 0xf8000);
         mem_mapping_add(&bios_mapping[7], 0xfc000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                         mem_write_nullw, mem_write_nulll, rom + (0x3c000 & biosmask), MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x3c000, 0xfc000);
 
         mem_mapping_add(&bios_high_mapping[0], (AT && cpu_16bitbus) ? 0xfe0000 : 0xfffe0000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x20000 & biosmask), MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x20000, (AT && cpu_16bitbus) ? 0xfe0000 : 0xfffe0000);
         mem_mapping_add(&bios_high_mapping[1], (AT && cpu_16bitbus) ? 0xfe4000 : 0xfffe4000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x24000 & biosmask), MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x24000, (AT && cpu_16bitbus) ? 0xfe4000 : 0xfffe4000);
         mem_mapping_add(&bios_high_mapping[2], (AT && cpu_16bitbus) ? 0xfe8000 : 0xfffe8000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x28000 & biosmask), MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x28000, (AT && cpu_16bitbus) ? 0xfe8000 : 0xfffe8000);
         mem_mapping_add(&bios_high_mapping[3], (AT && cpu_16bitbus) ? 0xfec000 : 0xfffec000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x2c000 & biosmask), MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x2c000, (AT && cpu_16bitbus) ? 0xfec000 : 0xfffec000);
         mem_mapping_add(&bios_high_mapping[4], (AT && cpu_16bitbus) ? 0xff0000 : 0xffff0000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x30000 & biosmask), MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x30000, (AT && cpu_16bitbus) ? 0xff0000 : 0xffff0000);
         mem_mapping_add(&bios_high_mapping[5], (AT && cpu_16bitbus) ? 0xff4000 : 0xffff4000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x34000 & biosmask), MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x34000, (AT && cpu_16bitbus) ? 0xff4000 : 0xffff4000);
         mem_mapping_add(&bios_high_mapping[6], (AT && cpu_16bitbus) ? 0xff8000 : 0xffff8000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x38000 & biosmask), MEM_MAPPING_ROM, 0);
+        WHPX_MAP_ROM(0x38000, (AT && cpu_16bitbus) ? 0xff8000 : 0xffff8000);
         mem_mapping_add(&bios_high_mapping[7], (AT && cpu_16bitbus) ? 0xffc000 : 0xffffc000, 0x04000, mem_read_bios,
                         mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll,
                         rom + (0x3c000 & biosmask), MEM_MAPPING_ROM, 0);
-        if (biosmask == 0x3ffff)
+        WHPX_MAP_ROM(0x3c000, (AT && cpu_16bitbus) ? 0xffc000 : 0xffffc000);
+        if (biosmask == 0x3ffff) {
                 mem_mapping_add(&bios_high_mapping[8], (AT && cpu_16bitbus) ? 0xfc0000 : 0xfffc0000, 0x20000, mem_read_bios,
                                 mem_read_biosw, mem_read_biosl, mem_write_null, mem_write_nullw, mem_write_nulll, rom,
                                 MEM_MAPPING_ROM, 0);
+                WHPX_MAP_ROM(0x00000, (AT && cpu_16bitbus) ? 0xfc0000 : 0xfffc0000);
+        }
 }
 
 int mem_a20_key = 0, mem_a20_alt = 0;

--- a/src/whpx.c
+++ b/src/whpx.c
@@ -118,12 +118,6 @@ int whpx_init(void)
                           &written);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvGetCapability(HypervisorPresent)", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvGetCapability(HypervisorPresent) failed", hr);
-#else
-        pclog("whpx: WHvGetCapability(HypervisorPresent) failed: 0x%lx\n", hr);
-#endif
-
         return -1;
     }
 
@@ -137,12 +131,6 @@ int whpx_init(void)
     hr = WHvCreatePartition(&whpx_partition);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvCreatePartition", hr);
-
-#ifdef _WIN32
-        whpx_log_hresult("WHvCreatePartition failed", hr);
-#else
-        pclog("whpx: WHvCreatePartition failed: 0x%lx\n", hr);
-#endif
         return -1;
     }
 
@@ -152,24 +140,13 @@ int whpx_init(void)
                                  WHvPartitionPropertyCodeProcessorCount,
                                  &prop, sizeof(prop));
     if (FAILED(hr)) {
-
         whpx_log_hresult("WHvSetPartitionProperty", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvSetPartitionProperty failed", hr);
-#else
-        pclog("whpx: WHvSetPartitionProperty failed: 0x%lx\n", hr);
-#endif
         return -1;
     }
 
     hr = WHvSetupPartition(whpx_partition);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvSetupPartition", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvSetupPartition failed", hr);
-#else
-        pclog("whpx: WHvSetupPartition failed: 0x%lx\n", hr);
-#endif
         return -1;
     }
 
@@ -197,15 +174,10 @@ int whpx_vcpu_create(void)
     HRESULT hr = WHvCreateVirtualProcessor(whpx_partition, whpx_vcpu_id, 0);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvCreateVirtualProcessor", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvCreateVirtualProcessor failed", hr);
 #ifdef E_INVALIDARG
         if (hr == E_INVALIDARG)
             pclog("whpx: invalid arguments when creating the vCPU. "
                   "Ensure PCem is built for 64-bit and RAM is page aligned.\n");
-#endif
-#else
-        pclog("whpx: WHvCreateVirtualProcessor failed: 0x%lx\n", hr);
 #endif
         return -1;
     }
@@ -236,15 +208,28 @@ int whpx_map_memory(void *mem, size_t size)
                                  WHvMapGpaRangeFlagExecute);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvMapGpaRange", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvMapGpaRange failed", hr);
-#else
-        pclog("whpx: WHvMapGpaRange failed: 0x%lx\n", hr);
-#endif
 #ifdef E_INVALIDARG
         if (hr == E_INVALIDARG)
             pclog("whpx: buffer or size not 4 KB aligned or running 32-bit build\n");
 #endif
+        return -1;
+    }
+    return 0;
+}
+
+int whpx_map_rom(const void *mem, unsigned long long gpa, size_t size)
+{
+    if (!whpx_partition)
+        return -1;
+
+    /* Replace any existing mapping for this GPA range */
+    WHvUnmapGpaRange(whpx_partition, gpa, size);
+
+    HRESULT hr = WHvMapGpaRange(whpx_partition, (void *)mem, gpa, size,
+                                 WHvMapGpaRangeFlagRead |
+                                 WHvMapGpaRangeFlagExecute);
+    if (FAILED(hr)) {
+        whpx_log_hresult("WHvMapGpaRange(ROM)", hr);
         return -1;
     }
     return 0;
@@ -256,13 +241,6 @@ void whpx_vcpu_destroy(void)
         HRESULT hr = WHvDeleteVirtualProcessor(whpx_partition, whpx_vcpu_id);
         if (FAILED(hr))
             whpx_log_hresult("WHvDeleteVirtualProcessor", hr);
-        if (FAILED(hr)) {
-#ifdef _WIN32
-            whpx_log_hresult("WHvDeleteVirtualProcessor failed", hr);
-#else
-            pclog("whpx: WHvDeleteVirtualProcessor failed: 0x%lx\n", hr);
-#endif
-        }
         whpx_vcpu_created = 0;
     }
 }
@@ -342,11 +320,6 @@ static int whpx_sync_to_vcpu(void)
         whpx_partition, whpx_vcpu_id, regs, idx, vals);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvSetVirtualProcessorRegisters", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvSetVirtualProcessorRegisters failed", hr);
-#else
-        pclog("whpx: WHvSetVirtualProcessorRegisters failed: 0x%lx\n", hr);
-#endif
         return -1;
     }
     return 0;
@@ -379,11 +352,6 @@ static int whpx_sync_from_vcpu(WHV_RUN_VP_EXIT_CONTEXT *ctx)
         whpx_partition, whpx_vcpu_id, regs, idx, vals);
     if (FAILED(hr)) {
         whpx_log_hresult("WHvGetVirtualProcessorRegisters", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvGetVirtualProcessorRegisters failed", hr);
-#else
-        pclog("whpx: WHvGetVirtualProcessorRegisters failed: 0x%lx\n", hr);
-#endif
         return -1;
     }
 
@@ -439,7 +407,7 @@ static int whpx_sync_from_vcpu(WHV_RUN_VP_EXIT_CONTEXT *ctx)
 
 int whpx_vcpu_run(void)
 {
-    WHV_RUN_VP_EXIT_CONTEXT exit_ctx;
+    WHV_RUN_VP_EXIT_CONTEXT exit_ctx = {0};
     if (!whpx_partition)
         return -1;
 
@@ -450,16 +418,13 @@ int whpx_vcpu_run(void)
                                          sizeof(exit_ctx));
     if (FAILED(hr)) {
         whpx_log_hresult("WHvRunVirtualProcessor", hr);
-#ifdef _WIN32
-        whpx_log_hresult("WHvRunVirtualProcessor failed", hr);
-#else
-        pclog("whpx: WHvRunVirtualProcessor failed: 0x%lx\n", hr);
-#endif
         return -1;
     }
 
     if (whpx_sync_from_vcpu(&exit_ctx) != 0)
         return -1;
+
+    pclog("whpx: exit reason %u\n", exit_ctx.ExitReason);
 
     switch (exit_ctx.ExitReason) {
     case WHvRunVpExitReasonX64Halt:
@@ -468,7 +433,14 @@ int whpx_vcpu_run(void)
     case WHvRunVpExitReasonX64IoPortAccess:
         /* Unhandled exits will be emulated by the interpreter */
         return 0;
+#ifdef WHvRunVpExitReasonNone
+    case WHvRunVpExitReasonNone:
+        pclog("whpx: no exit reason provided; vCPU state unchanged\n");
+        return -1;
+#endif
     default:
+        pclog("whpx: unexpected exit reason %u\n", exit_ctx.ExitReason);
+        /* Handle unrecognized exits with the interpreter */
         return 0;
     }
 }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable(check-whpx check-whpx.c)
 if(WIN32)
+    add_executable(check-whpx check-whpx.c)
     find_library(WINHVPLATFORM_LIB WinHvPlatform)
     if(WINHVPLATFORM_LIB)
         target_link_libraries(check-whpx ${WINHVPLATFORM_LIB})


### PR DESCRIPTION
## Summary
- remove redundant `whpx_log_hresult` calls
- ensure `WHvRunVirtualProcessor`'s exit context is zero-initialized
- map BIOS ROM ranges for WHPX

## Testing
- `cmake -S . -B build` *(fails: SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d64f7dbe4832c8e26e4cd60d6a40a