### PR TITLE
Fix function definition after merge

### DIFF
--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -77,16 +77,6 @@ static uint8_t ff_array[0x1000];
 #define WHPX_MAP_ROM(off, addr) do { } while (0)
 #endif
 
-#ifdef USE_WHPX
-#define WHPX_MAP_ROM(off, addr) \
-    do { \
-        if (cpu_backend == CPU_BACKEND_WHPX) \
-            whpx_map_rom(rom + ((off) & biosmask), (addr), 0x4000); \
-    } while (0)
-#else
-#define WHPX_MAP_ROM(off, addr) do { } while (0)
-#endif
-
 int mem_size;
 uint32_t biosmask;
 int readlnum = 0, writelnum = 0;
@@ -1279,6 +1269,8 @@ void mem_set_mem_state(uint32_t base, uint32_t size, int state) {
 
         mem_mapping_recalc(base, size);
 }
+
+void mem_add_bios() {
 
         if (AT || (romset == ROM_XI8088 && xi8088_bios_128kb())) {
                 mem_mapping_add(&bios_mapping[0], 0xe0000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,


### PR DESCRIPTION
## Summary
- restore missing `mem_add_bios` function header
- remove duplicated `WHPX_MAP_ROM` macro block
- reconfigure & build project to ensure compilation succeeds

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..`
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_686d7b728880832cb67bd25da1e31d01