### PR TITLE
Handle WHPX HLT exit

### DIFF
--- a/src/whpx.c
+++ b/src/whpx.c
@@ -433,11 +433,6 @@ int whpx_vcpu_run(void)
     switch (exit_ctx.ExitReason) {
     case WHvRunVpExitReasonX64Halt:
         pclog("whpx: HLT encountered, continuing execution\n");
-        if (cpu_state.pc == 0xFFF0) {
-            const uint8_t *p = rom + 0x3FFF0;
-            pclog("whpx: BIOS vector bytes: %02X %02X %02X %02X\n",
-                  p[0], p[1], p[2], p[3]);
-        }
         /* continue execution so the interpreter can handle pending IRQs */
         return 0;
     case WHvRunVpExitReasonMemoryAccess:


### PR DESCRIPTION
## Summary
- ignore WHPX HLT exits

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_686d7dff7898832c8550417cb9233fd8