### PR TITLE
Add VGA mapping for WHPX

### DIFF
--- a/includes/private/whpx.h
+++ b/includes/private/whpx.h
@@ -13,6 +13,7 @@ void whpx_vcpu_destroy(void);
 int whpx_vcpu_run(void);
 int whpx_map_memory(void *mem, size_t size);
 int whpx_map_rom(const void *mem, unsigned long long gpa, size_t size);
+int whpx_map_range(void *mem, unsigned long long gpa, size_t size);
 
 #ifdef __cplusplus
 }

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -9,6 +9,10 @@
 #include "io.h"
 #include "timer.h"
 #include "viewer.h"
+#include "cpu_backend.h"
+#ifdef USE_WHPX
+#include "whpx.h"
+#endif
 
 #define svga_output 0
 
@@ -786,6 +790,10 @@ int svga_init(svga_t *svga, void *p, int memsize, void (*recalctimings_ex)(struc
 
         mem_mapping_add(&svga->mapping, 0xa0000, 0x20000, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel,
                         NULL, MEM_MAPPING_EXTERNAL, svga);
+#ifdef USE_WHPX
+        if (cpu_backend == CPU_BACKEND_WHPX)
+                whpx_map_range(svga->vram, 0xA0000, 0x20000);
+#endif
 
         timer_add(&svga->timer, svga_poll, svga, 1);
 

--- a/src/whpx.c
+++ b/src/whpx.c
@@ -381,6 +381,21 @@ int whpx_map_rom(const void *mem, unsigned long long gpa, size_t size)
     return 0;
 }
 
+int whpx_map_range(void *mem, unsigned long long gpa, size_t size)
+{
+    if (!whpx_partition)
+        return -1;
+
+    HRESULT hr = WHvMapGpaRange(whpx_partition, mem, gpa, size,
+                                 WHvMapGpaRangeFlagRead |
+                                 WHvMapGpaRangeFlagWrite);
+    if (FAILED(hr)) {
+        whpx_log_hresult("WHvMapGpaRange(range)", hr);
+        return -1;
+    }
+    return 0;
+}
+
 void whpx_vcpu_destroy(void)
 {
     if (whpx_partition && whpx_vcpu_created) {
@@ -626,6 +641,7 @@ int whpx_vcpu_create(void) { return -1; }
 void whpx_vcpu_destroy(void) {}
 int whpx_vcpu_run(void) { return -1; }
 int whpx_map_memory(void *mem, size_t size) { return -1; }
+int whpx_map_range(void *mem, unsigned long long gpa, size_t size) { return -1; }
 #endif /* _WIN32 */
 
 #else /* !USE_WHPX */


### PR DESCRIPTION
## Summary
- expose `whpx_map_range` in the WHPX interface
- map VGA VRAM (A0000-BFFFF) for WHPX during SVGA initialization

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "SDL2")*

------
https://chatgpt.com/codex/tasks/task_e_686d9708bed0832cb2e7c491e85d4f90