### PR TITLE
Add CPU state log on getpccache failure

### DIFF
--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -18,6 +18,7 @@
 #include "video.h"
 #include "x86.h"
 #include "cpu.h"
+#include "cpu_debug.h"
 #include "rom.h"
 #include "x86_ops.h"
 #include "codegen.h"
@@ -476,6 +477,7 @@ uint8_t *getpccache(uint32_t a) {
         }
 
         pclog("Bad getpccache %08X\n", a);
+        cpu_log_state("Bad getpccache");
         return &ff_array[0 - (uintptr_t)(a2 & ~0xFFF)];
 }
 


### PR DESCRIPTION
## Summary
- include cpu_debug in mem.c
- log CPU state when `getpccache` encounters an unmapped page

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..` *(fails: SDL2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686da333e4ac832c9770e3dd2e8b68bd