### PR TITLE
Map VGA memory for WHPX

### DIFF
--- a/src/flash/rom.c
+++ b/src/flash/rom.c
@@ -6,6 +6,10 @@
 #include "mem.h"
 #include "rom.h"
 #include "paths.h"
+#ifdef USE_WHPX
+#include "cpu_backend.h"
+#include "whpx.h"
+#endif
 
 FILE *romfopen(char *fn, char *mode) {
         FILE *f;
@@ -66,6 +70,10 @@ int rom_init(rom_t *rom, char *fn, uint32_t address, int size, int mask, int fil
 
         mem_mapping_add(&rom->mapping, address, size, rom_read, rom_readw, rom_readl, mem_write_null, mem_write_nullw,
                         mem_write_nulll, rom->rom, flags | MEM_MAPPING_ROM, rom);
+#ifdef USE_WHPX
+        if (cpu_backend == CPU_BACKEND_WHPX)
+                whpx_map_rom(rom->rom, address, size);
+#endif
 
         return 0;
 }
@@ -102,6 +110,10 @@ int rom_init_interleaved(rom_t *rom, char *fn_low, char *fn_high, uint32_t addre
 
         mem_mapping_add(&rom->mapping, address, size, rom_read, rom_readw, rom_readl, mem_write_null, mem_write_nullw,
                         mem_write_nulll, rom->rom, flags | MEM_MAPPING_ROM, rom);
+#ifdef USE_WHPX
+        if (cpu_backend == CPU_BACKEND_WHPX)
+                whpx_map_rom(rom->rom, address, size);
+#endif
 
         return 0;
 }

--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -27,6 +27,30 @@
 #include "cpu_backend.h"
 #include "whpx.h"
 #endif
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <execinfo.h>
+#endif
+
+static void log_stack_trace(void)
+{
+#if defined(_WIN32)
+    void *frames[16];
+    USHORT n = CaptureStackBackTrace(0, 16, frames, NULL);
+    for (USHORT i = 1; i < n; i++)
+        pclog("  [%u] %p\n", i, frames[i]);
+#else
+    void *frames[16];
+    int n = backtrace(frames, 16);
+    char **syms = backtrace_symbols(frames, n);
+    if (syms) {
+        for (int i = 1; i < n; i++)
+            pclog("  %s\n", syms[i]);
+        free(syms);
+    }
+#endif
+}
 
 /* Log the BIOS reset vector to help diagnose ROM mapping issues */
 static void log_bios_reset_vector(void)
@@ -478,6 +502,7 @@ uint8_t *getpccache(uint32_t a) {
 
         pclog("Bad getpccache %08X\n", a);
         cpu_log_state("Bad getpccache");
+        log_stack_trace();
         return &ff_array[0 - (uintptr_t)(a2 & ~0xFFF)];
 }
 

--- a/src/whpx.c
+++ b/src/whpx.c
@@ -368,6 +368,26 @@ int whpx_map_memory(void *mem, size_t size)
 #endif
         return -1;
     }
+
+    /* Map 128 KB of VGA memory (0xA0000-0xBFFFF) */
+    if (size < 0x1000000) {
+        pclog("whpx: RAM size below 16 MB\n");
+        return -1;
+    }
+
+    hr = WHvMapGpaRange(
+        whpx_partition,
+        (uint8_t *)whpx_ram + 0xA0000,
+        0xA0000,
+        0x20000,
+        WHvMapGpaRangeFlagRead |
+        WHvMapGpaRangeFlagWrite);
+    if (FAILED(hr)) {
+        whpx_log_hresult("WHvMapGpaRange (video RAM)", hr);
+        return -1;
+    } else {
+        pclog("whpx: VGA memory area 0xA0000-0xBFFFF mapped successfully\n");
+    }
     return 0;
 }
 
@@ -647,6 +667,9 @@ int whpx_vcpu_run(void)
 
     if (whpx_sync_from_vcpu(&exit_ctx) != 0)
         return -1;
+
+    if (cpu_state.pc >= 0xA0000 && cpu_state.pc <= 0xBFFFF)
+        pclog("whpx: PC in VGA memory: %05X\n", cpu_state.pc);
 
     pclog("whpx: exit reason %u\n", exit_ctx.ExitReason);
 


### PR DESCRIPTION
## Summary
- map VGA RAM when using WHPX
- ensure at least 16 MB of RAM before mapping
- log stack trace on Bad getpccache
- dump PC when it falls in VGA memory region during WHPX run
- map ROMs for WHPX back-end

## Testing
- `cmake -S . -B build -G "Ninja" -DUSE_WHPX=ON` *(fails: SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da4998c94832cb47f01e5794659bd