### PR TITLE
Add VGA ROM debug helper

### DIFF
--- a/includes/private/memory/mem.h
+++ b/includes/private/memory/mem.h
@@ -213,6 +213,7 @@ void flushmmucache_cr3();
 
 /* Diagnostic helper to print the first bytes of VGA RAM */
 void debug_dump_vga_memory(void);
+void debug_dump_vga_rom_signature(void);
 
 void resetreadlookup();
 

--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -1591,3 +1591,10 @@ void debug_dump_vga_memory(void)
     if (32 % 16)
         printf("\n");
 }
+
+/* Helper to print the VGA ROM signature bytes at 0xC0000 */
+void debug_dump_vga_rom_signature(void)
+{
+    printf("VGA ROM signature: %02X %02X %02X\n",
+           ram[0xC0000], ram[0xC0001], ram[0xC0002]);
+}

--- a/src/pc.c
+++ b/src/pc.c
@@ -261,6 +261,7 @@ void initpc(int argc, char *argv[]) {
         initvideo();
         mem_init();
         loadbios();
+        debug_dump_vga_rom_signature();
 
         // this is now done per-model
         // mem_add_bios();


### PR DESCRIPTION
## Summary
- add `debug_dump_vga_rom_signature` helper to print VGA ROM signature
- expose new helper in `mem.h`
- print VGA ROM signature after BIOS load in `pc.c`

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..` *(fails: FindSDL2.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_686db8741a0c832c9a8cebc511f4d1f7