### PR TITLE
Add logging for loaded ROM file

### DIFF
--- a/src/flash/rom.c
+++ b/src/flash/rom.c
@@ -62,6 +62,8 @@ int rom_init(rom_t *rom, char *fn, uint32_t address, int size, int mask, int fil
                 return -1;
         }
 
+        pclog("Loading ROM image : %s\n", fn);
+
 #if defined(_WIN32) && defined(USE_WHPX)
         /* WHPX requires guest memory to be page aligned and executable. */
         rom->rom = VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE,


### PR DESCRIPTION
## Summary
- add a `pclog` call in `rom_init` to log the ROM file being loaded

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release .` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_686e2df73e54832c99a74472a013190b