### PR TITLE
Fix WHPX VGA memory mapping

### DIFF
--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -773,7 +773,18 @@ int svga_init(svga_t *svga, void *p, int memsize, void (*recalctimings_ex)(struc
         svga->dispontime = 1000ull << 32;
         svga->dispofftime = 1000ull << 32;
         svga->bpp = 8;
-        svga->vram = malloc(memsize);
+#ifdef USE_WHPX
+        if (cpu_backend == CPU_BACKEND_WHPX) {
+                /*
+                 * When WHPX acceleration is active the CPU fetches VGA data
+                 * directly from system RAM. Point the framebuffer into the
+                 * main memory buffer and map the range for the hypervisor.
+                 */
+                svga->vram = ram + 0xA0000;
+                whpx_map_range(svga->vram, 0xA0000, 0x20000);
+        } else
+#endif
+                svga->vram = malloc(memsize);
         svga->vram_max = memsize;
         svga->vram_display_mask = memsize - 1;
         svga->vram_mask = memsize - 1;
@@ -790,11 +801,6 @@ int svga_init(svga_t *svga, void *p, int memsize, void (*recalctimings_ex)(struc
 
         mem_mapping_add(&svga->mapping, 0xa0000, 0x20000, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel,
                         NULL, MEM_MAPPING_EXTERNAL, svga);
-#ifdef USE_WHPX
-        if (cpu_backend == CPU_BACKEND_WHPX)
-                whpx_map_vga_memory(svga->vram);
-
-#endif
 
         timer_add(&svga->timer, svga_poll, svga, 1);
 
@@ -812,7 +818,10 @@ int svga_init(svga_t *svga, void *p, int memsize, void (*recalctimings_ex)(struc
 
 void svga_close(svga_t *svga) {
         free(svga->changedvram);
-        free(svga->vram);
+#ifdef USE_WHPX
+        if (cpu_backend != CPU_BACKEND_WHPX)
+#endif
+                free(svga->vram);
 
         svga_pri = NULL;
 }


### PR DESCRIPTION
## Summary
- allocate VGA framebuffer inside main RAM when WHPX is active
- map the framebuffer range for WHPX
- don't free the shared RAM on shutdown

## Testing
- `cmake -S . -B build` *(fails: SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3a55424c832c92f22934ddb35e00