### PR TITLE
Add ROM size validation and fix path helper

### DIFF
--- a/src/flash/rom.c
+++ b/src/flash/rom.c
@@ -64,6 +64,17 @@ int rom_init(rom_t *rom, char *fn, uint32_t address, int size, int mask, int fil
 
         pclog("Loading ROM image : %s\n", fn);
 
+        /* Verify file size to detect truncated ROMs */
+        fseek(f, 0, SEEK_END);
+        long file_size = ftell(f);
+        if (file_size < file_offset + size) {
+                fclose(f);
+                pclog("ROM image %s is too small: %ld bytes, need %d\n", fn,
+                      file_size, file_offset + size);
+                return -1;
+        }
+        fseek(f, file_offset, SEEK_SET);
+
 #if defined(_WIN32) && defined(USE_WHPX)
         /* WHPX requires guest memory to be page aligned and executable. */
         rom->rom = VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE,
@@ -71,7 +82,6 @@ int rom_init(rom_t *rom, char *fn, uint32_t address, int size, int mask, int fil
 #else
         rom->rom = malloc(size);
 #endif
-        fseek(f, file_offset, SEEK_SET);
         fread(rom->rom, size, 1, f);
         fclose(f);
 

--- a/src/flash/rom.c
+++ b/src/flash/rom.c
@@ -102,7 +102,7 @@ int rom_init(rom_t *rom, char *fn, uint32_t address, int size, int mask, int fil
 }
 
 int rom_init_interleaved(rom_t *rom, char *fn_low, char *fn_high, uint32_t address, int size, int mask, int file_offset,
-                         uint32_t flags) {
+                          uint32_t flags) {
         FILE *f_low = romfopen(fn_low, "rb");
         FILE *f_high = romfopen(fn_high, "rb");
         int c;
@@ -119,14 +119,28 @@ int rom_init_interleaved(rom_t *rom, char *fn_low, char *fn_high, uint32_t addre
                 return -1;
         }
 
+        /* Ensure interleaved ROM parts are large enough */
+        fseek(f_low, 0, SEEK_END);
+        long file_size_low = ftell(f_low);
+        fseek(f_high, 0, SEEK_END);
+        long file_size_high = ftell(f_high);
+        int part_size = file_offset + size / 2;
+        if (file_size_low < part_size || file_size_high < part_size) {
+                pclog("ROM image %s or %s is too small: low=%ld high=%ld, need %d\n",
+                      fn_low, fn_high, file_size_low, file_size_high, part_size);
+                fclose(f_low);
+                fclose(f_high);
+                return -1;
+        }
+        fseek(f_low, file_offset, SEEK_SET);
+        fseek(f_high, file_offset, SEEK_SET);
+
 #if defined(_WIN32) && defined(USE_WHPX)
         rom->rom = VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE,
                                PAGE_EXECUTE_READWRITE);
 #else
         rom->rom = malloc(size);
 #endif
-        fseek(f_low, file_offset, SEEK_SET);
-        fseek(f_high, file_offset, SEEK_SET);
         for (c = 0; c < size; c += 2) {
                 rom->rom[c] = getc(f_low);
                 rom->rom[c + 1] = getc(f_high);

--- a/src/plugin-api/config.c
+++ b/src/plugin-api/config.c
@@ -406,10 +406,12 @@ void append_slash(char *s, int size) {
 }
 
 void put_backslash(char *s) {
-        int c = strlen(s) - 1;
-        if (s[c] != '/' && s[c] != '\\') {
-                s[c + 1] = '/';
-                s[c + 2] = 0;
+        int len = strlen(s);
+        if (!len)
+                return;
+        if (s[len - 1] != '/' && s[len - 1] != '\\') {
+                s[len] = '/';
+                s[len + 1] = 0;
         }
 }
 


### PR DESCRIPTION
## Summary
- check ROM file size in `rom_init` to catch truncated ROMs
- make `put_backslash` safe with empty strings

## Testing
- `cmake ..` *(fails: FindSDL2.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4187b54832ca48859ceead02e2e