### PR TITLE
Fix getpccache for mapped ranges

### DIFF
--- a/includes/private/ibm.h
+++ b/includes/private/ibm.h
@@ -24,6 +24,7 @@
 
 /*Memory*/
 extern uint8_t *ram;
+extern size_t ram_size;
 
 extern uint32_t rammask;
 

--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 #include <stdio.h>
 #if defined(_WIN32) && defined(USE_WHPX)
 #include <windows.h>
@@ -110,6 +111,7 @@ int readlnum = 0, writelnum = 0;
 int cachesize = 256;
 
 uint8_t *ram, *rom = NULL;
+size_t ram_size = 0;
 uint8_t romext[32768];
 
 uint64_t *byte_dirty_mask;
@@ -493,6 +495,9 @@ uint8_t *getpccache(uint32_t a) {
         }
         a &= rammask;
 
+        if (a >= 0xA0000 && a < 0xC0000)
+                pclog("getpccache: VGA access at 0x%05X\n", a);
+
         if (_mem_exec[a >> 14]) {
                 if (read_mapping[a >> 14]->flags & MEM_MAPPING_ROM)
                         cpu_prefetch_cycles = cpu_rom_prefetch_cycles;
@@ -502,7 +507,10 @@ uint8_t *getpccache(uint32_t a) {
                 return &_mem_exec[a >> 14][(uintptr_t)(a & 0x3000) - (uintptr_t)(a2 & ~0xFFF)];
         }
 
-        pclog("Bad getpccache %08X\n", a);
+        if (a < ram_size)
+                return &ram[a];
+
+        pclog("getpccache: invalid access 0x%05X (outside RAM)\n", a);
         cpu_log_state("Bad getpccache");
         log_stack_trace();
         return &ff_array[0 - (uintptr_t)(a2 & ~0xFFF)];
@@ -1440,6 +1448,7 @@ void mem_alloc() {
         free(ram);
         ram = malloc(mem_size * 1024);
 #endif
+        ram_size = mem_size * 1024;
         memset(ram, 0, mem_size * 1024);
 
         free(byte_dirty_mask);
@@ -1578,6 +1587,14 @@ void debug_dump_vga_memory(void)
             }
             if (32 % 16)
                 printf("\n");
+
+            for (int i = 0; i < 0x20000; i++) {
+                if (svga->vram[i] != 0x00) {
+                    printf("VGA RAM initialized: data at 0x%05X = %02X\n",
+                           0xA0000 + i, svga->vram[i]);
+                    break;
+                }
+            }
             return;
         }
     }
@@ -1590,14 +1607,27 @@ void debug_dump_vga_memory(void)
     }
     if (32 % 16)
         printf("\n");
+
+    for (int i = 0; i < 0x20000; i++) {
+        if (ram[0xA0000 + i] != 0x00) {
+            printf("VGA RAM initialized: data at 0x%05X = %02X\n",
+                   0xA0000 + i, ram[0xA0000 + i]);
+            break;
+        }
+    }
 }
 
-/* Helper to print the VGA ROM signature bytes at 0xC0000 */
+/* Helper to verify and print the VGA ROM signature bytes at 0xC0000 */
 void debug_dump_vga_rom_signature(void)
 {
     if (!ram) {
         printf("VGA ROM signature: RAM not allocated yet\n");
         return;
+    }
+
+    if (ram[0xC0000] != 0x55 || ram[0xC0001] != 0xAA) {
+        fprintf(stderr, "Error: VGA ROM signature invalid or not loaded.\n");
+        exit(1);
     }
 
     printf("VGA ROM signature: %02X %02X %02X\n",


### PR DESCRIPTION
## Summary
- expose RAM size for runtime checks
- track RAM size when allocating memory
- log VGA frame buffer fetches
- return direct RAM pointer from getpccache when within mapped memory
- clarify invalid getpccache message
- validate VGA ROM signature and RAM contents

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_686ecd52ebe0832c84c098d3600a82af