### PR TITLE
Fix WHPX RAM pointer usage

### DIFF
--- a/includes/private/whpx.h
+++ b/includes/private/whpx.h
@@ -15,6 +15,7 @@ int whpx_map_memory(void *mem, size_t size);
 int whpx_map_rom(const void *mem, unsigned long long gpa, size_t size);
 int whpx_map_range(void *mem, unsigned long long gpa, size_t size);
 int whpx_map_vga_memory(void *mem);
+void *whpx_get_ram_base(void);
 
 #ifdef __cplusplus
 }

--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -507,6 +507,13 @@ uint8_t *getpccache(uint32_t a) {
                 return &_mem_exec[a >> 14][(uintptr_t)(a & 0x3000) - (uintptr_t)(a2 & ~0xFFF)];
         }
 
+#ifdef USE_WHPX
+        if (cpu_backend == CPU_BACKEND_WHPX) {
+                uint8_t *base = whpx_get_ram_base();
+                if (a < ram_size)
+                        return &base[a];
+        } else
+#endif
         if (a < ram_size)
                 return &ram[a];
 
@@ -1621,16 +1628,25 @@ void debug_dump_vga_memory(void)
 /* Helper to verify and print the VGA ROM signature bytes at 0xC0000 */
 void debug_dump_vga_rom_signature(void)
 {
+    /*
+     * The VGA BIOS might be stored in a separate ROM buffer rather than
+     * mirrored into the main RAM array.  Use physical memory reads so the
+     * check works regardless of backend or mapping strategy.
+     */
+
     if (!ram) {
         printf("VGA ROM signature: RAM not allocated yet\n");
         return;
     }
 
-    if (ram[0xC0000] != 0x55 || ram[0xC0001] != 0xAA) {
+    uint8_t sig0 = mem_readb_phys(0xC0000);
+    uint8_t sig1 = mem_readb_phys(0xC0001);
+
+    if (sig0 != 0x55 || sig1 != 0xAA) {
         fprintf(stderr, "Error: VGA ROM signature invalid or not loaded.\n");
         exit(1);
     }
 
     printf("VGA ROM signature: %02X %02X %02X\n",
-           ram[0xC0000], ram[0xC0001], ram[0xC0002]);
+           sig0, sig1, mem_readb_phys(0xC0002));
 }

--- a/src/whpx.c
+++ b/src/whpx.c
@@ -454,6 +454,11 @@ int whpx_map_vga_memory(void *mem)
     return -1;
 }
 
+void *whpx_get_ram_base(void)
+{
+    return whpx_ram;
+}
+
 void whpx_vcpu_destroy(void)
 {
     if (whpx_partition && whpx_vcpu_created) {
@@ -742,6 +747,7 @@ int whpx_vcpu_run(void) { return -1; }
 int whpx_map_memory(void *mem, size_t size) { return -1; }
 int whpx_map_range(void *mem, unsigned long long gpa, size_t size) { return -1; }
 int whpx_map_vga_memory(void *mem) { return -1; }
+void *whpx_get_ram_base(void) { return NULL; }
 #endif /* _WIN32 */
 
 #else /* !USE_WHPX */


### PR DESCRIPTION
## Summary
- expose WHPX RAM base pointer
- use WHPX RAM base in `getpccache`
- validate VGA ROM via physical reads

## Testing
- `cmake -S . -B build` *(fails: Could NOT find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_686ed59624e0832cbf6485c0ec2d3ca0