### PR TITLE
Delay machine start until user runs

### DIFF
--- a/src/wx-ui/wx-app.cc
+++ b/src/wx-ui/wx-app.cc
@@ -97,9 +97,9 @@ void Frame::Start() {
 }
 
 void Frame::ShowConfigSelection() {
-        if (wx_load_config(this))
-                start_emulation(this);
-        else
+        if (wx_load_config(this)) {
+                wx_show_status(this);
+        } else
                 Quit(1);
 }
 

--- a/src/wx-ui/wx-status.cc
+++ b/src/wx-ui/wx-status.cc
@@ -224,6 +224,7 @@ void resume_emulation();
 void pause_emulation();
 int stop_emulation_confirm();
 void reset_emulation();
+int start_emulation(void *);
 
 void hdconf_open(void *hwnd);
 void config_open(void *hwnd);
@@ -274,7 +275,10 @@ void StatusFrame::UpdateToolbar() {
 
 void StatusFrame::OnCommand(wxCommandEvent &event) {
         if (event.GetId() == XRCID("TOOLBAR_RUN")) {
-                resume_emulation();
+                if (emulation_state == EMULATION_STOPPED)
+                        start_emulation(GetParent());
+                else
+                        resume_emulation();
                 UpdateToolbar();
         } else if (event.GetId() == XRCID("TOOLBAR_PAUSE")) {
                 pause_emulation();


### PR DESCRIPTION
## Summary
- open status window after config selection instead of starting immediately
- allow toolbar run button to start the machine when stopped

## Testing
- `cmake ..` *(fails: FindSDL2.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ed8440d6c832cb5c921f28213be48