### PR TITLE
Improve VGA init failure handling

### DIFF
--- a/src/plugin-api/device.c
+++ b/src/plugin-api/device.c
@@ -309,7 +309,7 @@ void pcem_add_device(device_t *d) {
         if (d->init != NULL) {
                 priv = d->init();
                 if (priv == NULL)
-                        fatal("device_add : device init failed\n");
+                        fatal("%s initialization failed\n", d->name);
         }
 
         devices[c] = d;

--- a/src/video/vid_vga.c
+++ b/src/video/vid_vga.c
@@ -104,8 +104,11 @@ void *vga_init() {
         vga_t *vga = malloc(sizeof(vga_t));
         memset(vga, 0, sizeof(vga_t));
 
-        if (rom_init(&vga->bios_rom, "ibm_vga.bin", 0xc0000, 0x8000, 0x7fff, 0x2000, MEM_MAPPING_EXTERNAL))
+        if (rom_init(&vga->bios_rom, "ibm_vga.bin", 0xc0000, 0x8000, 0x7fff, 0x2000, MEM_MAPPING_EXTERNAL)) {
                 error("Failed to load VGA BIOS ROM 'ibm_vga.bin'. Check roms path.\n");
+                free(vga);
+                return NULL;
+        }
 
         svga_init(&vga->svga, vga, 1 << 18, /*256kb*/
                   NULL, vga_in, vga_out, NULL, NULL);


### PR DESCRIPTION
## Summary
- free VGA struct and return `NULL` if ROM init fails
- report which device failed to initialize

## Testing
- `cmake ..` *(fails: missing SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_686ee587c1e0832cacf943667006621f