### PR TITLE
Conditionally dump VGA ROM

### DIFF
--- a/includes/private/video/video.h
+++ b/includes/private/video/video.h
@@ -34,6 +34,7 @@ int video_get_video_from_internal_name(char *s);
 int video_is_mda();
 int video_is_cga();
 int video_is_ega_vga();
+int video_has_vga_rom();
 
 extern int video_fullscreen, video_fullscreen_scale, video_fullscreen_first;
 extern int video_force_aspect_ration;

--- a/src/pc.c
+++ b/src/pc.c
@@ -372,11 +372,13 @@ void resetpchard() {
         model_init();
         mouse_emu_init();
         video_init();
+        if (video_has_vga_rom()) {
 #ifdef USE_WHPX
-        if (cpu_backend == CPU_BACKEND_WHPX)
-                debug_dump_vga_memory();
+                if (cpu_backend == CPU_BACKEND_WHPX)
+                        debug_dump_vga_memory();
 #endif
-        debug_dump_vga_rom_signature();
+                debug_dump_vga_rom_signature();
+        }
         speaker_init();
         lpt1_device_init();
 

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -531,6 +531,17 @@ int video_is_ega_vga() {
         return (video_cards[video_old_to_new(gfxcard)]->flags & VIDEO_FLAG_TYPE_MASK) == VIDEO_FLAG_TYPE_SPECIAL;
 }
 
+/*
+ * Return non-zero when the current video card is expected to
+ * provide a VGA-compatible option ROM at 0xC0000. Cards such as
+ * MDA or CGA lack a VGA BIOS, so debug helpers probing the ROM
+ * should be skipped.
+ */
+int video_has_vga_rom()
+{
+        return video_is_ega_vga();
+}
+
 int video_fullscreen = 0, video_fullscreen_scale, video_fullscreen_first;
 int video_force_aspect_ration = 0;
 int vid_disc_indicator = 0;


### PR DESCRIPTION
## Summary
- add `video_has_vga_rom()` helper to determine if a VGA BIOS is expected
- guard debug ROM/memory dumps behind this helper

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release .`
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_686ee5ac2154832cb079e08f26f81491