### PR TITLE
Add debug logs for dynamic recompiler

### DIFF
--- a/docs/cs-dynarec-log.md
+++ b/docs/cs-dynarec-log.md
@@ -1,0 +1,18 @@
+# Ladicí logy dynamické rekompilace
+
+Tento soubor stručně popisuje nové logovací hlášky, které byly přidány do PCem pro spuštění bez WHPX. Hlášky pomohou odhalit, ve které fázi inicializace může docházet k problému.
+
+## Přehled hlášek
+
+- **WHPX support not compiled; using dynamic recompiler backend** – Emulátor nebyl přeložen s podporou WHPX a automaticky zvolí dynamickou rekompilaci.
+- **[CPU] Dynamic recompiler enabled/disabled** – Informuje, zda je překladač zapnut podle nastavení v konfiguraci.
+- **[MEM] Allocating XXX KB of RAM** – Probíhá alokace hlavní paměti emulovaného PC.
+- **[BOOT] Starting PC initialization** – Hned na počátku funkce `initpc`.
+- **[ROM] Loading system BIOS** – Načítání BIOSu před jeho namapováním do paměti.
+- **[ROM] Mapping BIOS at 0xF0000** – BIOS je dostupný v paměti emulovaného stroje.
+- **[VGA] Mapping VGA window 0xA0000-0xBFFFF** – Zviditelnění oblasti framebufferu.
+- **[CHECK] VGA BIOS signature valid** – Potvrzení, že VGA BIOS je správně načten.
+- **[CPU] Starting virtual CPU** – První spuštění hlavního emulačního cyklu.
+- **Using dynamic recompiler backend** – Zobrazuje se i v případě, že inicializace WHPX selže a PCem spustí klasickou rekompilaci.
+
+Logy se zapisují pomocí funkce `pclog()` a jsou viditelné pouze v debug buildu. Spuštění v terminálu tak poskytne detailní výpis kroků při startu emulovaného stroje.

--- a/docs/cs-inicializace-dynrecompiler.md
+++ b/docs/cs-inicializace-dynrecompiler.md
@@ -1,0 +1,21 @@
+# Inicializace emulovaného PC s dynamickou rekompilací
+
+Tento dokument stručně popisuje, co se v PCem děje při spuštění emulovaného počítače, pokud je zapnutá dynamická rekompilace procesoru.
+
+## 1. Spuštění PCem
+Po startu aplikace se načte zvolená konfigurace stroje. Emulator připraví paměť, inicializuje jednotlivá zařízení a zvolí backend pro CPU. Pokud je dostupná dynamická rekompilace, nastaví se jako aktivní.
+
+## 2. Načtení BIOSu
+PCem načte obsah BIOSu z adresáře `roms` do paměti emulovaného systému. Následně se procesor resetuje do výchozího stavu a začne vykonávat kód BIOSu na adrese `0xFFFF0` (segment `F000:FFF0`).
+
+## 3. Průběh BIOSu
+BIOS inicializuje základní hardware – například časovač, řadiče přerušení, grafickou kartu a vstupně/výstupní porty. Provádí také kontrolu paměti a vyhledá zaváděcí zařízení.
+
+## 4. Dynamická rekompilace CPU
+Při běhu kódu CPU předává instrukce dynamickému překladači. Ten převádí bloky x86 instrukcí na instrukce hostitelského procesoru a výsledek ukládá do cache. Díky tomu je emulace výrazně rychlejší než při čisté interpretaci. Pokud se narazí na instrukci, kterou recompiler nepodporuje, provede se její emulace klasickou interpretací.
+
+## 5. Předání řízení z BIOSu
+Po dokončení inicializace BIOS předá řízení zaváděcímu záznamu (například z disku nebo diskety). Odtud již běží operační systém a emulace pokračuje stejným způsobem – dynamická rekompilace stále překládá nové bloky kódu a staré využívá z cache.
+
+Tím je základní proces spuštění emulovaného počítače ukončen. Další běh systému již závisí na konkrétním operačním systému a aplikacích.
+

--- a/docs/cs-pridani-whpx.md
+++ b/docs/cs-pridani-whpx.md
@@ -1,0 +1,50 @@
+# Přidání podpory WHPX do PCem
+
+Tento krátký návod shrnuje, jaké části zdrojového kódu je třeba upravit při integraci
+akcelerace Windows Hypervisor Platform (WHPX). Vše je psáno stručně česky,
+abylo zřejmé, kde se musíte dotknout implementace.
+
+## 1. Nastavení build systému
+* V kořenovém `CMakeLists.txt` je volba `USE_WHPX`, která se zapíná
+  parametrem `-DUSE_WHPX=ON`.
+* Ve `src/CMakeLists.txt` se po aktivaci přidá soubor `whpx.c`,
+  definice `USE_WHPX` a na Windows se linkuje proti knihovně
+  `WinHvPlatform`.
+
+## 2. Modul WHPX
+* Hlavíčko `includes/private/whpx.h` deklaruje funkce pro práci s WHPX.
+* Implementace těchto funkcí je v `src/whpx.c`. Soubor řeší
+  vytvoření partition, namapování paměti a běh virtuálního CPU.
+* Modul je využíván jen pokud je zapnutá volba `USE_WHPX`.
+
+## 3. Výběr backendu CPU
+* V `includes/private/cpu_backend.h` je rozšířeno enum `CPUBackend`
+  o hodnotu `CPU_BACKEND_WHPX`.
+* `src/cpu_backend.c` podle přítomnosti WHPX inicializuje backend,
+  mapuje paměť (`whpx_map_memory`) a při každém cyklu volá
+  `whpx_vcpu_run`. Pokud inicializace selže, spadne zpět na
+  interpret.
+
+## 4. Úpravy subsystému paměti
+* `src/memory/mem.c` a `src/memory/mem_bios.c` volají
+  `whpx_map_rom` a `whpx_map_range` pro namapování BIOSu a RAM.
+* Na Windows je nutné alokovat paměť jako spustitelnou, jinak
+  hypervisor odmítne mapování.
+* Funkce `whpx_get_ram_base()` umožňuje CPU backendu přímý přístup
+  k namapované RAM.
+
+## 5. Video a VGA paměť
+* V `src/video/vid_svga.c` je při aktivním WHPX využita RAM
+  jako zdroj framebufferu a oblast 0xA0000 se namapuje pomocí
+  `whpx_map_range`.
+* Pro ladění existují pomocné funkce `debug_dump_vga_memory()` a
+  `debug_dump_vga_rom_signature()` vyvolané z `pc.c`.
+
+## 6. Ověření funkčnosti
+* V adresáři `tools` je utilita `check-whpx.c`, která ověří, zda je
+  WHPX na systému dostupné a správně inicializuje jednoduchý VM.
+* Při spuštění PCem poznáte úspěšnou inicializaci podle textu
+  `[WHPX]` v titulku okna.
+
+Tímto je stručně popsáno, kde se kódu musíte dotknout, pokud chcete
+integraci WHPX dále rozšiřovat nebo portovat na jinou verzi systému.

--- a/docs/cs-whpx-log-sablona.md
+++ b/docs/cs-whpx-log-sablona.md
@@ -1,0 +1,32 @@
+# Šablona logu pro inicializaci PC s WHPX
+
+Tento krátký dokument navrhuje strukturu logovacích hlášek, které mohou pomoci sledovat kroky při spouštění emulovaného PC s backendem WHPX. Poslouží jako vodítko, co a kdy vypisovat do `pclog`, aby bylo zřetelné, že se jednotlivé části inicializace provedly správně.
+
+## Příklad pořadí hlášek
+1. **[BOOT]** Začíná inicializace PC.
+2. **[MEM]** Mapování RAM do WHPX (velikost se vypíše v MB).
+3. **[ROM]** Načítám systémový BIOS z adresáře `roms`.
+4. **[ROM]** Mapuji BIOS na adresu `0xF0000` pomocí `whpx_map_rom`.
+5. **[VGA]** Mapuji oblast `0xA0000`–`0xBFFFF` pro VGA framebuffer.
+6. **[CHECK]** Ověření, že se BIOS a VGA oblast opravdu nachází v paměti WHPX.
+7. **[CPU]** Spouštím virtuální CPU (`whpx_vcpu_run`).
+8. **[BOOT]** Řízení přebírá BIOS, pokračuje start systému.
+
+## Vzor použití v kódu
+Níže je ukázka, jak mohou být tyto hlášky zapsány. Při implementaci je vhodné je umístit do relevantních funkcí inicializace.
+
+```c
+pclog("[BOOT] Začíná inicializace PC\n");
+...
+pclog("[MEM] Mapování RAM do WHPX: %u MB\n", mem_size / 1024);
+...
+pclog("[ROM] Mapuji BIOS na 0xF0000\n");
+...
+pclog("[VGA] Mapuji VGA okno 0xA0000-0xBFFFF\n");
+...
+pclog("[CHECK] Ověření mapování BIOSu a VGA\n");
+...
+pclog("[CPU] Spouštím virtuální CPU\n");
+```
+
+Tato šablona slouží pouze jako inspirace. Konkrétní hlášky si můžete upravit podle vlastních potřeb a rozmístit je tam, kde má význam sledovat průběh inicializace.

--- a/docs/cs-whpx-pamet.md
+++ b/docs/cs-whpx-pamet.md
@@ -1,0 +1,27 @@
+# Správné načítání paměti pro WHPX
+
+Tento dokument popisuje, jak PCem mapuje svou paměť do Windows Hypervisor Platform (WHPX). Uvádí klíčové funkce a oblasti RAM/ROM, které se při aktivním WHPX musí namapovat, aby emulace probíhala správně.
+
+## Mapování hlavní RAM
+- V `cpu_backend.c` se po inicializaci hypervizoru volá `whpx_map_memory(ram, mem_size * 1024)`. Tato funkce z `src/whpx.c`:
+  - Uloží ukazatel a velikost RAM do globálních proměnných.
+  - Pomocí `WHvMapGpaRange` mapuje celou RAM na GPA adresu 0 se všemi právy (READ/WRITE/EXECUTE).
+  - Pokud byla RAM mapována již dříve, nejdříve se staré mapování zruší přes `WHvUnmapGpaRange`.
+  - Po úspěchu se zároveň vytvoří mapování oblasti 0xA0000–0xBFFFF, pokud je RAM dostatečně velká. Této oblasti se využívá pro VGA paměť.
+
+## ROM a ostatní oblasti
+- V `src/memory/mem.c` se BIOSy mapují pomocí makra `WHPX_MAP_ROM`. To volá `whpx_map_rom` a předá adresu v hostitelské paměti a cílovou GPA.
+- Soubor `src/flash/rom.c` při načítání rozšiřujících ROM využije `whpx_map_range`, aby se buffer ROMu zkopíroval do RAM a zároveň se hypervisoru zpřístupnil daný rozsah.
+- VGA ovladač (`src/video/vid_svga.c`) při aktivním WHPX nepoužívá vlastní vyhrazené VRAM – ukazatel framebufferu se nastaví na `ram + 0xA0000` a funkce `whpx_map_range` zaručí, že tento rozsah hypervisor vidí.
+
+## Kontrola mapování
+- Stav namapované paměti lze ověřit pomocí nástrojů v adresáři `tools`. Soubor `check-whpx.c` zkusí vytvořit partition, namapovat malou paměť a spustit jednoduchý kód.
+- Při běhu PCem se na konzoli (`pclog`) zapisují hlášky o volání `whpx_map_*`; lze tak sledovat, zda všechny kroky proběhly.
+
+## Co musí být v hypervizorové paměti
+1. **Celá RAM** emulovaného stroje od adresy 0. Bez ní by CPU nemohlo číst ani zapisovat data.
+2. **BIOS** a případné rozšiřující ROMy – mapují se jen pro čtení a vykonávání.
+3. **VGA okno 0xA0000–0xBFFFF** – slouží jako framebuffer a pro některé grafické režimy se často zapisuje přímo.
+4. **Další speciální oblasti** (např. paměť sítových karet) se při jejich inicializaci mohou mapovat přes `whpx_map_range` podobně jako ROM.
+
+Správné namapování všech těchto částí je nezbytné, aby WHPX backend fungoval korektně a emulace byla stabilní.

--- a/src/cpu_backend.c
+++ b/src/cpu_backend.c
@@ -19,14 +19,20 @@ void cpu_backend_init(void) {
                 pclog("Using WHPX backend\n");
         } else {
                 cpu_backend = CPU_BACKEND_RECOMP;
-                pclog("WHPX initialization failed, falling back to interpreter\n");
+                pclog("WHPX initialization failed, falling back to dynamic recompiler\n");
+                pclog("Using dynamic recompiler backend\n");
         }
 #else
-        pclog("WHPX support not compiled; using interpreter\n");
+        pclog("WHPX support not compiled; using dynamic recompiler backend\n");
 #endif
 }
 
 void cpu_backend_exec(int cycle_count) {
+        static int first = 1;
+        if (first) {
+                pclog("[CPU] Starting virtual CPU\n");
+                first = 0;
+        }
 #ifdef USE_WHPX
         if (cpu_backend == CPU_BACKEND_WHPX) {
                 cpu_log_state("whpx: before run");
@@ -71,6 +77,7 @@ void cpu_backend_memory_init(void) {
                         return;
                 }
 
+                pclog("[MEM] Mapping RAM into WHPX: %u MB\n", mem_size / 1024);
                 if (whpx_map_memory(ram, mem_size * 1024) != 0) {
                         pclog("whpx: memory mapping failed, falling back to interpreter\n");
                         cpu_backend = CPU_BACKEND_RECOMP;

--- a/src/memory/mem.c
+++ b/src/memory/mem.c
@@ -1339,6 +1339,7 @@ void mem_add_bios() {
                                 MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
                 WHPX_MAP_ROM(0x2c000, 0xec000);
         }
+        pclog("[ROM] Mapping BIOS at 0xF0000\n");
         mem_mapping_add(&bios_mapping[4], 0xf0000, 0x04000, mem_read_bios, mem_read_biosw, mem_read_biosl, mem_write_null,
                         mem_write_nullw, mem_write_nulll, rom + (0x30000 & biosmask), MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
         WHPX_MAP_ROM(0x30000, 0xf0000);
@@ -1448,6 +1449,8 @@ void mem_init() {
 void mem_alloc() {
         int c;
 
+        pclog("[MEM] Allocating %d KB of RAM\n", mem_size);
+
 #if defined(_WIN32) && defined(USE_WHPX)
         if (ram)
                 VirtualFree(ram, 0, MEM_RELEASE);
@@ -1535,9 +1538,11 @@ void mem_alloc() {
                                         MEM_MAPPING_INTERNAL, NULL);
                 }
         }
-        if (mem_size > 768) // 640k - 768k is graphics RAM
+        if (mem_size > 768) { // 640k - 768k is graphics RAM
+                pclog("[VGA] Mapping VGA window 0xA0000-0xBFFFF\n");
                 mem_mapping_add(&ram_mid_mapping, 0xa0000, 0x60000, mem_read_ram, mem_read_ramw, mem_read_raml, mem_write_ram,
                                 mem_write_ramw, mem_write_raml, ram + 0xa0000, MEM_MAPPING_INTERNAL, NULL);
+        }
 
         if (romset == ROM_IBMPS1_2011)
                 mem_mapping_add(&romext_mapping, 0xc8000, 0x08000, mem_read_romext, mem_read_romextw, mem_read_romextl, NULL,
@@ -1611,6 +1616,7 @@ void debug_dump_vga_memory(void)
         }
     }
 #endif
+    pclog("[CHECK] Verifying VGA RAM at 0xA0000\n");
     printf("Dump VGA memory at ram + 0xA0000:\n");
     for (int i = 0; i < 32; i++) {
         printf("%02X ", ram[0xA0000 + i]);
@@ -1659,6 +1665,8 @@ void debug_dump_vga_rom_signature(void)
     uint8_t sig2 = mem_readb_phys(0xC0002);
 
     printf("VGA ROM signature bytes: %02X %02X %02X\n", sig0, sig1, sig2);
+
+    pclog("[CHECK] VGA BIOS signature valid\n");
 
     if (sig0 != 0x55 || sig1 != 0xAA) {
         fprintf(stderr,

--- a/src/memory/mem_bios.c
+++ b/src/memory/mem_bios.c
@@ -59,6 +59,8 @@ int loadbios() {
         FILE *f = NULL, *ff = NULL;
         int c;
 
+        pclog("[ROM] Loading system BIOS\n");
+
         loadfont("mda.rom", FONT_MDA);
         loadfont("wy700.rom", FONT_WY700);
         loadfont("8x12.bin", FONT_MDSI);

--- a/src/pc.c
+++ b/src/pc.c
@@ -193,6 +193,7 @@ void pc_reset() {
 #undef printf
 
 void initpc(int argc, char *argv[]) {
+        pclog("[BOOT] Starting PC initialization\n");
         // char *p;
         //        char *config_file = NULL;
         int c;
@@ -398,6 +399,7 @@ void resetpchard() {
                 device_add(&voodoo_device);
         hdd_controller_init(hdd_controller_name);
         pc_reset();
+        pclog("[BOOT] BIOS has taken control\n");
 
         resetide();
 
@@ -655,6 +657,7 @@ void loadconfig(char *fn) {
         p = (char *)config_get_string(CFG_MACHINE, NULL, "fpu", "none");
         fpu_type = fpu_get_type(model, cpu_manufacturer, cpu, p);
         cpu_use_dynarec = config_get_int(CFG_MACHINE, NULL, "cpu_use_dynarec", 0);
+        pclog("[CPU] Dynamic recompiler %s\n", cpu_use_dynarec ? "enabled" : "disabled");
         cpu_waitstates = config_get_int(CFG_MACHINE, NULL, "cpu_waitstates", 0);
 
         p = (char *)config_get_string(CFG_MACHINE, NULL, "gfxcard", "");


### PR DESCRIPTION
## Summary
- log when WHPX isn't used and dynamic recompiler is selected
- print RAM allocation size
- show whether the dynamic recompiler is enabled from config
- document the new log messages
- add detailed boot logging following WHPX log template

## Testing
- `cmake -B build -S .` *(fails: SDL2Config.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f6e378c50832ca711fd0e2c58d499