### PR TITLE
Improve ROM detection

### DIFF
--- a/src/wx-ui/wx-sdl2.c
+++ b/src/wx-ui/wx-sdl2.c
@@ -117,6 +117,29 @@ int video_height = 480;
 
 char menuitem[60];
 
+static int romset_dir_exists(int romset) {
+    char base[512];
+    char path[512];
+    const char *name;
+    int i, model_idx;
+
+    model_idx = model_getmodel(romset);
+    if (model_idx < 0 || models[model_idx] == NULL)
+        return 0;
+
+    name = models[model_idx]->internal_name;
+
+    for (i = 0; i < num_roms_paths; i++) {
+        if (!get_roms_path(i, base, sizeof(base)))
+            continue;
+        append_slash(base, sizeof(base));
+        snprintf(path, sizeof(path), "%s%s", base, name);
+        if (dir_exists(path))
+            return 1;
+    }
+    return 0;
+}
+
 extern int config_selection_open(void *hwnd, int inited);
 extern int shader_manager_open(void *hwnd);
 
@@ -497,10 +520,10 @@ int wx_start(void *hwnd) {
         wx_setupmenu(0);
 
         d = romset;
-        for (c = 0; c < ROM_MAX; c++) {
-                romset = c;
-                romspresent[c] = loadbios();
-                //        pclog("romset %i - %i\n", c, romspresent[c]);
+        memset(romspresent, 0, sizeof(romspresent));
+        for (c = 0; models[c] != NULL; c++) {
+                int rs = models[c]->id;
+                romspresent[rs] = romset_dir_exists(rs);
         }
 
         for (c = 0; c < ROM_MAX; c++) {


### PR DESCRIPTION
## Summary
- avoid repeated BIOS loads when checking available ROMs
- detect ROM sets by directory presence instead of loading the BIOS files

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..` *(fails: could not find SDL2)*
- `ninja` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_687001791a20832cac348b5ee150c296