### PR TITLE
Fix whpx CPU reset state

### DIFF
--- a/includes/private/whpx.h
+++ b/includes/private/whpx.h
@@ -17,6 +17,7 @@ int whpx_map_range(void *mem, unsigned long long gpa, size_t size);
 int whpx_map_vga_memory(void *mem);
 void *whpx_get_ram_base(void);
 size_t whpx_get_ram_size(void);
+int whpx_reset_vcpu(void);
 
 #ifdef __cplusplus
 }

--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -26,6 +26,10 @@
 #include "timer.h"
 #include "x86.h"
 #include "x87.h"
+#ifdef USE_WHPX
+#include "cpu_backend.h"
+#include "whpx.h"
+#endif
 #include "paths.h"
 
 uint64_t xt_cpu_multi;
@@ -697,6 +701,10 @@ void resetx86() {
         codegen_reset();
         x86_was_reset = 1;
         cpu_state.smbase = 0x30000;
+#ifdef USE_WHPX
+        if (cpu_backend == CPU_BACKEND_WHPX)
+                whpx_reset_vcpu();
+#endif
 }
 
 void softresetx86() {
@@ -739,6 +747,10 @@ void softresetx86() {
         flushmmucache();
         x86_was_reset = 1;
         FETCHCLEAR();
+#ifdef USE_WHPX
+        if (cpu_backend == CPU_BACKEND_WHPX)
+                whpx_reset_vcpu();
+#endif
 }
 
 static void setznp8(uint8_t val) {

--- a/src/whpx.c
+++ b/src/whpx.c
@@ -341,6 +341,14 @@ int whpx_vcpu_create(void)
     return 0;
 }
 
+int whpx_reset_vcpu(void)
+{
+    if (!whpx_partition || !whpx_vcpu_created)
+        return -1;
+    pclog("whpx: resetting VCPU state\n");
+    return init_real_mode_registers();
+}
+
 int whpx_map_memory(void *mem, size_t size)
 {
     if (!whpx_partition)
@@ -754,8 +762,10 @@ int whpx_map_range(void *mem, unsigned long long gpa, size_t size) { return -1; 
 int whpx_map_vga_memory(void *mem) { return -1; }
 void *whpx_get_ram_base(void) { return NULL; }
 size_t whpx_get_ram_size(void) { return 0; }
+int whpx_reset_vcpu(void) { return -1; }
 #endif /* _WIN32 */
 
 #else /* !USE_WHPX */
 int whpx_dummy; /* avoid empty object file */
+int whpx_reset_vcpu(void) { return -1; }
 #endif /* USE_WHPX */


### PR DESCRIPTION
## Summary
- add `whpx_reset_vcpu` API
- use `whpx_reset_vcpu` after CPU reset and soft reset

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` *(fails: SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700a0b0b20832cb2a5262e23ae81a4