### PR TITLE
Fix missing OpenGL ES menu items

### DIFF
--- a/src/wx-ui/pc.xrc
+++ b/src/wx-ui/pc.xrc
@@ -201,14 +201,22 @@
 					<label>Direct3D</label>
 					<radio>1</radio>
 				</object>
-				<object class="wxMenuItem" name="IDM_VID_RENDER_DRIVER[2]">
-					<label>OpenGL</label>
-					<radio>1</radio>
-				</object>
-				<object class="wxMenuItem" name="IDM_VID_RENDER_DRIVER[6]">
-					<label>OpenGL 3.0</label>
-					<radio>1</radio>
-				</object>
+                                <object class="wxMenuItem" name="IDM_VID_RENDER_DRIVER[2]">
+                                        <label>OpenGL</label>
+                                        <radio>1</radio>
+                                </object>
+                                <object class="wxMenuItem" name="IDM_VID_RENDER_DRIVER[3]">
+                                        <label>OpenGL ES 2</label>
+                                        <radio>1</radio>
+                                </object>
+                                <object class="wxMenuItem" name="IDM_VID_RENDER_DRIVER[4]">
+                                        <label>OpenGL ES</label>
+                                        <radio>1</radio>
+                                </object>
+                                <object class="wxMenuItem" name="IDM_VID_RENDER_DRIVER[6]">
+                                        <label>OpenGL 3.0</label>
+                                        <radio>1</radio>
+                                </object>
 				<object class="wxMenuItem" name="IDM_VID_RENDER_DRIVER[5]">
 					<label>Software</label>
 					<radio>1</radio>


### PR DESCRIPTION
## Summary
- add OpenGL ES 2 and OpenGL ES render driver menu items to `pc.xrc`

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release .` *(fails: SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_687014cfdd04832c944e8f6ed06b1d05