### PR TITLE
Fix WHPX real-mode segments

### DIFF
--- a/src/whpx.c
+++ b/src/whpx.c
@@ -26,7 +26,7 @@
 #endif
 
 /* Attribute values for real-mode segments */
-#define WHPX_REAL_MODE_CODE_ATTR 0x009B /* present, exec/read, 16-bit */
+#define WHPX_REAL_MODE_CODE_ATTR 0x0093 /* real-mode code, execute/read */
 #define WHPX_REAL_MODE_DATA_ATTR 0x0093 /* present, read/write, 16-bit */
 
 struct whpx_hr_entry {


### PR DESCRIPTION
## Summary
- use a real-mode compatible attribute for CS in the WHPX backend

## Testing
- `cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..` *(fails: SDL2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f3816b7c832c880f363b795c2b53