### PR TITLE
Fix WHPX load BIOS utility initialization

### DIFF
--- a/tools/check-whpx.c
+++ b/tools/check-whpx.c
@@ -16,6 +16,10 @@
 /* Older headers may use a Flags field */
 #define SEGATTR(seg) ((seg).Flags)
 #endif
+
+/* Real-mode segment attribute values */
+#define WHPX_REAL_MODE_CODE_ATTR 0x0093 /* execute/read */
+#define WHPX_REAL_MODE_DATA_ATTR 0x0092 /* read/write */
 #endif
 
 struct whpx_hr_entry {
@@ -226,7 +230,7 @@ int main(int argc, char **argv)
     reg_vals[n].Segment.Selector = 0;
     if (real_mode) {
         reg_vals[n].Segment.Limit = 0xFFFF;
-        SEGATTR(reg_vals[n].Segment) = 0x0093; /* 16-bit */
+        SEGATTR(reg_vals[n].Segment) = WHPX_REAL_MODE_CODE_ATTR; /* 16-bit */
     } else {
         reg_vals[n].Segment.Limit = 0xFFFFFFFF;
         SEGATTR(reg_vals[n].Segment) = 0xC09B; /* flat 32-bit */
@@ -248,7 +252,7 @@ int main(int argc, char **argv)
             reg_vals[n].Segment.Base = 0;
             reg_vals[n].Segment.Limit = 0xFFFF;
             reg_vals[n].Segment.Selector = 0;
-            SEGATTR(reg_vals[n].Segment) = 0x0092; /* data */
+            SEGATTR(reg_vals[n].Segment) = WHPX_REAL_MODE_DATA_ATTR; /* data */
             n++;
         }
 

--- a/tools/load-bios-whpx.c
+++ b/tools/load-bios-whpx.c
@@ -15,6 +15,10 @@
 #define SEGATTR(seg) ((seg).Flags)
 #endif
 
+/* Real-mode segment attribute values */
+#define WHPX_REAL_MODE_CODE_ATTR 0x0093 /* execute/read */
+#define WHPX_REAL_MODE_DATA_ATTR 0x0092 /* read/write */
+
 static void log_hresult(const char *prefix, HRESULT hr)
 {
     char *msg = NULL;
@@ -155,8 +159,15 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    WHV_REGISTER_NAME regs[10];
-    WHV_REGISTER_VALUE vals[10];
+    /*
+     * Initialise the virtual CPU in 16-bit real mode similarly to
+     * check-whpx.c. If segment registers or descriptor tables are left
+     * undefined WHPX stops the vCPU with a MemoryAccess exit (reason 5)
+     * before the BIOS executes.  Provide a minimal real mode state so
+     * execution can begin at the reset vector.
+     */
+    WHV_REGISTER_NAME regs[16];
+    WHV_REGISTER_VALUE vals[16];
     int n = 0;
 
     regs[n] = WHvX64RegisterRip;
@@ -167,7 +178,7 @@ int main(int argc, char **argv)
     vals[n].Segment.Base = 0xF0000;
     vals[n].Segment.Limit = 0xFFFF;
     vals[n].Segment.Selector = 0xF000;
-    SEGATTR(vals[n].Segment) = 0x0093;
+    SEGATTR(vals[n].Segment) = WHPX_REAL_MODE_CODE_ATTR;
     n++;
 
     regs[n] = WHvX64RegisterRsp;
@@ -182,9 +193,34 @@ int main(int argc, char **argv)
         vals[n].Segment.Base = 0;
         vals[n].Segment.Limit = 0xFFFF;
         vals[n].Segment.Selector = 0;
-        SEGATTR(vals[n].Segment) = 0x0092;
+        SEGATTR(vals[n].Segment) = WHPX_REAL_MODE_DATA_ATTR; /* data */
         n++;
     }
+
+    /* Descriptor tables required for real mode startup */
+    regs[n] = WHvX64RegisterGdtr;
+    vals[n].Table.Base = 0;
+    vals[n].Table.Limit = 0xFFFF;
+    n++;
+
+    regs[n] = WHvX64RegisterIdtr;
+    vals[n].Table.Base = 0;
+    vals[n].Table.Limit = 0xFFFF;
+    n++;
+
+    regs[n] = WHvX64RegisterTr;
+    vals[n].Segment.Base = 0;
+    vals[n].Segment.Limit = 0xFFFF;
+    vals[n].Segment.Selector = 0;
+    SEGATTR(vals[n].Segment) = 0x008B;
+    n++;
+
+    regs[n] = WHvX64RegisterLdtr;
+    vals[n].Segment.Base = 0;
+    vals[n].Segment.Limit = 0xFFFF;
+    vals[n].Segment.Selector = 0;
+    SEGATTR(vals[n].Segment) = 0x0082;
+    n++;
 
     regs[n] = WHvX64RegisterCr0;
     vals[n].Reg64 = 0x10;


### PR DESCRIPTION
## Summary
- fix `load-bios-whpx` to initialize CPU registers correctly
- factor real-mode segment attribute values into macros

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_6871747cd4ec832c81ce26cf1ed50333