### PR TITLE
Fix globals and build on modern gcc

### DIFF
--- a/Readme-LINUX.txt
+++ b/Readme-LINUX.txt
@@ -9,12 +9,20 @@ OpenAL
 
 and their dependencies.
 
+On Debian/Ubuntu systems these can be installed with:
+
+  sudo apt-get install build-essential libsdl2-dev libwxgtk3.2-dev libopenal-dev
+
 Open a terminal window, navigate to the PCem directory then enter
 
 ./configure --enable-release
 make
 
 then ./pcem to run.
+
+For a 32-bit build on a 64-bit system, install multilib development packages and use:
+
+  make -f src/Makefile.linux32-wx-sdl2
 
 The Linux version stores BIOS ROM images, configuration files, and other data in ~/.pcem
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,7 +29,7 @@ codegen_ops_misc.c codegen_ops_mov.c codegen_ops_stack.c codegen_reg.c codegen_t
 cpu_tables.c dells200.c device.c disc.c disc_fdi.c disc_img.c disc_sector.c dma.c esdi_at.c fdc.c fdc37c665.c fdd.c fdi2raw.c gameport.c \
 hdd.c hdd_esdi.c hdd_file.c headland.c i430lx.c i430fx.c i430vx.c ide.c ide_atapi.c ide_sff8038i.c intel.c intel_flash.c io.c jim.c joystick_ch_flightstick_pro.c joystick_standard.c joystick_sw_pad.c \
 joystick_tm_fcs.c keyboard.c keyboard_amstrad.c keyboard_at.c keyboard_olim24.c keyboard_pcjr.c keyboard_xt.c \
-laserxt.c lpt.c lpt_dac.c lpt_dss.c mca.c mcr.c mem.c mem_bios.c mfm_at.c mfm_xebec.c model.c mouse.c mouse_msystems.c mouse_ps2.c mouse_serial.c mvp3.c neat.c nmi.c nvr.c olivetti_m24.c \
+laserxt.c lpt.c lpt_dac.c lpt_dss.c mca.c mcr.c mem.c mem_bios.c globals.c mfm_at.c mfm_xebec.c model.c mouse.c mouse_msystems.c mouse_ps2.c mouse_serial.c mvp3.c neat.c nmi.c nvr.c olivetti_m24.c \
 opti495.c paths.c pc.c pc87306.c pci.c pic.c piix.c pit.c ppi.c ps1.c ps2.c ps2_mca.c ps2_nvr.c nvr_tc8521.c rom.c rtc.c rtc_tc8521.c scat.c scsi.c scsi_53c400.c scsi_aha1540.c scsi_cd.c scsi_hd.c scsi_zip.c \
 serial.c sio.c sis496.c sl82c460.c sound.c sound_ad1848.c sound_adlib.c sound_adlibgold.c sound_audiopci.c sound_cms.c sound_emu8k.c sound_gus.c \
 sound_mpu401_uart.c sound_opl.c sound_pas16.c sound_ps1.c sound_pssj.c sound_sb.c sound_sb_dsp.c sound_sn76489.c \
@@ -55,7 +55,7 @@ resid-fp/wave6581_P_T.cc resid-fp/wave6581__ST.cc resid-fp/wave8580_PS_.cc \
 resid-fp/wave8580_PST.cc resid-fp/wave8580_P_T.cc resid-fp/wave8580__ST.cc \
 resid-fp/wave.cc
 
-pcem_CFLAGS = $(subst -fpermissive,,$(shell $(WX_CONFIG_PATH) --cxxflags) $(shell sdl2-config --cflags))
+pcem_CFLAGS = $(subst -fpermissive,,$(shell $(WX_CONFIG_PATH) --cxxflags) $(shell sdl2-config --cflags)) -fcommon
 pcem_CXXFLAGS = $(shell $(WX_CONFIG_PATH) --cxxflags) $(shell sdl2-config --cflags)
 pcem_LDADD = @LIBS@
 pcem_SOURCES += wx-main.cc wx-config_sel.c wx-dialogbox.cc wx-utils.cc wx-app.cc \
@@ -127,13 +127,19 @@ if !HAS_OFF64T
 #pcem_CFLAGS += -Doff64_t=off_t -Dfopen64=fopen -Dfseeko64=fseek -Dftello64=ftell
 endif
 
+# Release-specific flags
 if RELEASE_BUILD
 pcem_CFLAGS += -DRELEASE_BUILD
 pcem_CXXFLAGS += -DRELEASE_BUILD
 endif
 
+# Optimisation hint for the ARM64 build only. This causes problems when
+# building for other architectures such as x86_64, so wrap it in the
+# appropriate conditional.
+if CPU_ARM64
 pcem_CFLAGS += -mtune=cortex-a53
 pcem_CXXFLAGS += -mtune=cortex-a53
+endif
 #pcem_LDFLAGS = -flto -O3 -mtune=cortex-a15
 
 # pcem_CFLAGS += -fprofile-use

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -153,7 +153,7 @@ am__pcem_SOURCES_DIST = 386.c 386_dynarec.c 386_dynarec_ops.c 808x.c \
 	joystick_standard.c joystick_sw_pad.c joystick_tm_fcs.c \
 	keyboard.c keyboard_amstrad.c keyboard_at.c keyboard_olim24.c \
 	keyboard_pcjr.c keyboard_xt.c laserxt.c lpt.c lpt_dac.c \
-	lpt_dss.c mca.c mcr.c mem.c mem_bios.c mfm_at.c mfm_xebec.c \
+        lpt_dss.c mca.c mcr.c mem.c mem_bios.c globals.c mfm_at.c mfm_xebec.c \
 	model.c mouse.c mouse_msystems.c mouse_ps2.c mouse_serial.c \
 	neat.c nmi.c nvr.c olivetti_m24.c opti495.c paths.c pc.c \
 	pc87306.c pci.c pic.c piix.c pit.c ppi.c ps1.c ps2.c ps2_mca.c \
@@ -781,7 +781,7 @@ pcem_SOURCES = 386.c 386_dynarec.c 386_dynarec_ops.c 808x.c acc2036.c \
 	joystick_sw_pad.c joystick_tm_fcs.c keyboard.c \
 	keyboard_amstrad.c keyboard_at.c keyboard_olim24.c \
 	keyboard_pcjr.c keyboard_xt.c laserxt.c lpt.c lpt_dac.c \
-	lpt_dss.c mca.c mcr.c mem.c mem_bios.c mfm_at.c mfm_xebec.c \
+        lpt_dss.c mca.c mcr.c mem.c mem_bios.c globals.c mfm_at.c mfm_xebec.c \
 	model.c mouse.c mouse_msystems.c mouse_ps2.c mouse_serial.c \
 	neat.c nmi.c nvr.c olivetti_m24.c opti495.c paths.c pc.c \
 	pc87306.c pci.c pic.c piix.c pit.c ppi.c ps1.c ps2.c ps2_mca.c \
@@ -827,8 +827,8 @@ pcem_SOURCES = 386.c 386_dynarec.c 386_dynarec_ops.c 808x.c acc2036.c \
 	$(am__append_15) $(am__append_16) $(am__append_17) \
 	$(am__append_20)
 pcem_CFLAGS = $(subst -fpermissive,,$(shell $(WX_CONFIG_PATH) \
-	--cxxflags) $(shell sdl2-config --cflags)) $(am__append_7) \
-	$(am__append_11) $(am__append_18) $(am__append_22)
+        --cxxflags) $(shell sdl2-config --cflags)) $(am__append_7) \
+        $(am__append_11) $(am__append_18) $(am__append_22) -fcommon
 pcem_CXXFLAGS = $(shell $(WX_CONFIG_PATH) --cxxflags) $(shell \
 	sdl2-config --cflags) $(am__append_12) $(am__append_19) \
 	$(am__append_23)

--- a/src/codegen_allocator.c
+++ b/src/codegen_allocator.c
@@ -8,6 +8,7 @@
 
 #include "ibm.h"
 #include "codegen.h"
+#include <stdlib.h>
 #include "codegen_allocator.h"
 
 typedef struct mem_block_t

--- a/src/codegen_backend_x86-64.c
+++ b/src/codegen_backend_x86-64.c
@@ -13,6 +13,7 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <sys/mman.h>
 #include <unistd.h>
+#include <stdlib.h>
 #endif
 #if defined WIN32 || defined _WIN32 || defined _WIN32
 #include <windows.h>
@@ -312,7 +313,7 @@ void codegen_backend_init()
         host_x86_XOR32_REG_REG(block, REG_EDI, REG_EDI);
         host_x86_XOR32_REG_REG(block, REG_ESI, REG_ESI);
 #endif
-	host_x86_CALL(block, (uintptr_t)x86gpf);
+        host_x86_CALL(block, (void *)x86gpf);
         codegen_exit_rout = &codeblock[block_current].data[block_pos];
         host_x86_ADD64_REG_IMM(block, REG_RSP, 0x38);
         host_x86_POP(block, REG_R15);

--- a/src/disc.c
+++ b/src/disc.c
@@ -132,7 +132,7 @@ int disc_hole(int drive)
 	}
 }
 
-void disc_poll()
+void disc_poll(void *p)
 {
         timer_advance_u64(&disc_poll_timer, disc_period * TIMER_USEC);
 
@@ -283,7 +283,7 @@ void disc_stop(int drive)
         drive ^= fdd_swap;
         
         if (drive < 2 && drives[drive].stop)
-                drives[drive].stop(drive);
+                drives[drive].stop();
 }
 
 void disc_set_drivesel(int drive)

--- a/src/disc.h
+++ b/src/disc.h
@@ -33,7 +33,7 @@ void disc_set_drivesel(int drive);
 void disc_set_motor_enable(int motor_enable);
 extern int disc_drivesel;
 
-void fdc_callback();
+void fdc_callback(void *p);
 int  fdc_data(uint8_t dat);
 void fdc_spindown();
 void fdc_finishread();

--- a/src/disc.h
+++ b/src/disc.h
@@ -19,7 +19,7 @@ void disc_new(int drive, char *fn);
 void disc_close(int drive);
 void disc_init();
 void disc_reset();
-void disc_poll();
+void disc_poll(void *p);
 void disc_seek(int drive, int track);
 void disc_readsector(int drive, int sector, int track, int side, int density, int sector_size);
 void disc_writesector(int drive, int sector, int track, int side, int density, int sector_size);

--- a/src/fdc.c
+++ b/src/fdc.c
@@ -70,7 +70,7 @@ typedef struct FDC
 
 static FDC fdc;
 
-void fdc_callback();
+void fdc_callback(void *p);
 //#define SECTORS 9
 int lastbyte=0;
 uint8_t disc_3f7;
@@ -462,7 +462,7 @@ void fdc_write(uint16_t addr, uint8_t val, void *priv)
 //                                        fdc.stat = 0x10 | (fdc.stat & 0xf);
                                         discint = 8;
                                         fdc.pos = 0;
-                                        fdc_callback();
+                                        fdc_callback(NULL);
                                 }
                                 else
                                 {
@@ -493,13 +493,13 @@ void fdc_write(uint16_t addr, uint8_t val, void *priv)
                                 fdc.lastdrive = fdc.drive;
                                 discint = 0x0e;
                                 fdc.pos = 0;
-                                fdc_callback();
+                                fdc_callback(NULL);
                                 break;
                                 case 0x10: /*Get version*/
                                 fdc.lastdrive = fdc.drive;
                                 discint = 0x10;
                                 fdc.pos = 0;
-                                fdc_callback();
+                                fdc_callback(NULL);
                                 break;
                                 case 0x12: /*Set perpendicular mode*/
                                 fdc.pnum=0;
@@ -518,7 +518,7 @@ void fdc_write(uint16_t addr, uint8_t val, void *priv)
                                 fdc.lastdrive = fdc.drive;
                                 discint = fdc.command;
                                 fdc.pos = 0;
-                                fdc_callback();
+                                fdc_callback(NULL);
                                 break;
 
                                 case 0x18:
@@ -526,7 +526,7 @@ void fdc_write(uint16_t addr, uint8_t val, void *priv)
                                 fdc.lastdrive = fdc.drive;
                                 discint = 0x10;
                                 fdc.pos = 0;
-                                fdc_callback();
+                                fdc_callback(NULL);
                                 /* fdc.stat = 0x10;
                                 discint  = 0xfc;
                                 fdc_callback(); */
@@ -788,7 +788,7 @@ uint8_t fdc_read(uint16_t addr, void *priv)
         return temp;
 }
 
-void fdc_callback()
+void fdc_callback(void *p)
 {
         int temp;
         int doseek = 0;

--- a/src/globals.c
+++ b/src/globals.c
@@ -1,0 +1,29 @@
+#include "ibm.h"
+
+/* Definitions of global variables previously in ibm.h */
+
+uint8_t *ram;
+uint32_t rammask;
+int readlookup[256], readlookupp[256];
+uintptr_t *readlookup2;
+int readlnext;
+int writelookup[256], writelookupp[256];
+uintptr_t *writelookup2;
+int writelnext;
+PIT pit, pit2;
+dma_t dma[8];
+PPI ppi;
+PIC pic, pic2;
+char discfns[2][256];
+int driveempty[2];
+int GAMEBLASTER, GUS, SSI2001, voodoo_enabled;
+PcemHDC hdc[7];
+int keybsenddelay;
+
+int hasfpu;
+int romset;
+int gfxcard;
+int cpuspeed;
+int readflash;
+int ppispeakon;
+int gated, speakval, speakon;

--- a/src/ibm.h
+++ b/src/ibm.h
@@ -19,16 +19,16 @@
 #define readflash_get(offset, drive) ((readflash&(1<<((offset)+(drive)))) != 0)
 
 /*Memory*/
-uint8_t *ram;
+extern uint8_t *ram;
 
-uint32_t rammask;
+extern uint32_t rammask;
 
-int readlookup[256],readlookupp[256];
-uintptr_t *readlookup2;
-int readlnext;
-int writelookup[256],writelookupp[256];
-uintptr_t *writelookup2;
-int writelnext;
+extern int readlookup[256],readlookupp[256];
+extern uintptr_t *readlookup2;
+extern int readlnext;
+extern int writelookup[256],writelookupp[256];
+extern uintptr_t *writelookup2;
+extern int writelnext;
 
 extern int mmu_perm;
 
@@ -104,7 +104,7 @@ typedef struct PIT
         void (*set_out_funcs[3])(int new_out, int old_out);
 } PIT;
 
-PIT pit, pit2;
+extern PIT pit, pit2;
 void setpitclock(float clock);
 
 float pit_timer0_freq();
@@ -133,7 +133,7 @@ typedef struct dma_t
         uint16_t io_addr;
 } dma_t;
 
-dma_t dma[8];
+extern dma_t dma[8];
 
 /*PPI*/
 typedef struct PPI
@@ -142,7 +142,7 @@ typedef struct PPI
         uint8_t pa,pb;
 } PPI;
 
-PPI ppi;
+extern PPI ppi;
 
 
 /*PIC*/
@@ -155,16 +155,16 @@ typedef struct PIC
         uint8_t level_sensitive;
 } PIC;
 
-PIC pic,pic2;
+extern PIC pic,pic2;
 extern int pic_intpending;
 
 
-char discfns[2][256];
-int driveempty[2];
+extern char discfns[2][256];
+extern int driveempty[2];
 
 #define PCJR (romset == ROM_IBMPCJR)
 
-int GAMEBLASTER, GUS, SSI2001, voodoo_enabled;
+extern int GAMEBLASTER, GUS, SSI2001, voodoo_enabled;
 extern int AMSTRAD, AT, is386, PCI, TANDY;
 
 enum
@@ -248,8 +248,8 @@ enum
 
 extern int romspresent[ROM_MAX];
 
-int hasfpu;
-int romset;
+extern int hasfpu;
+extern int romset;
 
 enum
 {
@@ -291,13 +291,13 @@ enum
 
 extern int gfx_present[GFX_MAX];
 
-int gfxcard;
+extern int gfxcard;
 
-int cpuspeed;
+extern int cpuspeed;
 
 
 /*Video*/
-int readflash;
+extern int readflash;
 extern int egareads,egawrites;
 extern int vid_resize;
 extern int vid_api;
@@ -307,12 +307,12 @@ extern int changeframecount;
 
 
 /*Sound*/
-int ppispeakon;
+extern int ppispeakon;
 extern uint64_t CGACONST;
 extern uint64_t MDACONST;
 extern uint64_t VGACONST1,VGACONST2;
 extern uint64_t RTCCONST;
-int gated,speakval,speakon;
+extern int gated,speakval,speakon;
 
 
 /*Sound Blaster*/
@@ -337,10 +337,10 @@ typedef struct
         int tracks;
 } PcemHDC;
 
-PcemHDC hdc[7];
+extern PcemHDC hdc[7];
 
 /*Keyboard*/
-int keybsenddelay;
+extern int keybsenddelay;
 
 
 /*CD-ROM*/

--- a/src/ide.c
+++ b/src/ide.c
@@ -1172,12 +1172,12 @@ abort_cmd:
 	ide_irq_raise(ide);
 }
 
-void ide_callback_pri()
+void ide_callback_pri(void *p)
 {
 	callbackide(0);
 }
 
-void ide_callback_sec()
+void ide_callback_sec(void *p)
 {
 	callbackide(1);
 }

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -235,7 +235,7 @@ static int oldkey[272];
 static int keydelay[272];
 
 void (*keyboard_send)(uint8_t val);
-void (*keyboard_poll)();
+void (*keyboard_poll)(void *p);
 int keyboard_scan = 1;
 
 void keyboard_process()

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -1,5 +1,5 @@
 extern void (*keyboard_send)(uint8_t val);
-extern void (*keyboard_poll)();
+extern void (*keyboard_poll)(void *p);
 void keyboard_process();
 extern int keyboard_scan;
 

--- a/src/keyboard_amstrad.c
+++ b/src/keyboard_amstrad.c
@@ -35,7 +35,7 @@ static int key_queue_start = 0, key_queue_end = 0;
 
 static uint8_t amstrad_systemstat_1, amstrad_systemstat_2;
 
-void keyboard_amstrad_poll()
+void keyboard_amstrad_poll(void *p)
 {
         timer_advance_u64(&keyboard_amstrad.send_delay_timer, (1000 * TIMER_USEC));
         if (keyboard_amstrad.wantirq)

--- a/src/keyboard_amstrad.h
+++ b/src/keyboard_amstrad.h
@@ -1,3 +1,3 @@
 void keyboard_amstrad_init();
 void keyboard_amstrad_reset();
-void keyboard_amstrad_poll();
+void keyboard_amstrad_poll(void *p);

--- a/src/keyboard_at.c
+++ b/src/keyboard_at.c
@@ -65,7 +65,7 @@ static int key_queue_start = 0, key_queue_end = 0;
 static uint8_t mouse_queue[16];
 int mouse_queue_start = 0, mouse_queue_end = 0;
 
-void keyboard_at_poll()
+void keyboard_at_poll(void *p)
 {
 	timer_advance_u64(&keyboard_at.send_delay_timer, (100 * TIMER_USEC));
 

--- a/src/keyboard_at.h
+++ b/src/keyboard_at.h
@@ -1,7 +1,7 @@
 void keyboard_at_init();
 void keyboard_at_init_ps2();
 void keyboard_at_reset();
-void keyboard_at_poll();
+void keyboard_at_poll(void *p);
 void keyboard_at_set_mouse(void (*mouse_write)(uint8_t val, void *p), void *p);
 void keyboard_at_adddata_mouse(uint8_t val);
 

--- a/src/keyboard_olim24.c
+++ b/src/keyboard_olim24.c
@@ -43,7 +43,7 @@ static int key_queue_start = 0, key_queue_end = 0;
 
 static uint8_t mouse_scancodes[7];
 
-void keyboard_olim24_poll()
+void keyboard_olim24_poll(void *p)
 {
         timer_advance_u64(&keyboard_olim24.send_delay_timer, (1000 * TIMER_USEC));
         //pclog("poll %i\n", keyboard_olim24.wantirq);

--- a/src/keyboard_olim24.h
+++ b/src/keyboard_olim24.h
@@ -1,5 +1,5 @@
 void keyboard_olim24_init();
 void keyboard_olim24_reset();
-void keyboard_olim24_poll();
+void keyboard_olim24_poll(void *p);
 
 extern mouse_t mouse_olim24;

--- a/src/keyboard_pcjr.c
+++ b/src/keyboard_pcjr.c
@@ -39,7 +39,7 @@ struct
 static uint8_t key_queue[16];
 static int key_queue_start = 0, key_queue_end = 0;
 
-void keyboard_pcjr_poll()
+void keyboard_pcjr_poll(void *p)
 {
         timer_advance_u64(&keyboard_pcjr.send_delay_timer, (220 * TIMER_USEC));
 

--- a/src/keyboard_pcjr.h
+++ b/src/keyboard_pcjr.h
@@ -1,3 +1,3 @@
 void keyboard_pcjr_init();
 void keyboard_pcjr_reset();
-void keyboard_pcjr_poll();
+void keyboard_pcjr_poll(void *p);

--- a/src/keyboard_xt.c
+++ b/src/keyboard_xt.c
@@ -43,7 +43,7 @@ struct
 static uint8_t key_queue[16];
 static int key_queue_start = 0, key_queue_end = 0;
 
-void keyboard_xt_poll()
+void keyboard_xt_poll(void *p)
 {
         timer_advance_u64(&keyboard_xt.send_delay_timer, (1000 * TIMER_USEC));
         if (!(keyboard_xt.pb & 0x40) && romset != ROM_TANDY)

--- a/src/keyboard_xt.h
+++ b/src/keyboard_xt.h
@@ -1,4 +1,4 @@
 void keyboard_xt_init();
 void keyboard_tandy_init();
 void keyboard_xt_reset();
-void keyboard_xt_poll();
+void keyboard_xt_poll(void *p);

--- a/src/pc.c
+++ b/src/pc.c
@@ -425,7 +425,8 @@ void resetpchard()
 	network_card_init(network_card_current);      
 #endif
 
-        sound_card_init(sound_card_current);
+        /* Initialize using the globally selected card */
+        sound_card_init();
         if (GUS)
                 device_add(&gus_device);
         if (GAMEBLASTER)

--- a/src/pit.h
+++ b/src/pit.h
@@ -1,7 +1,7 @@
 extern uint64_t PITCONST;
 void pit_init();
 void pit_ps2_init();
-void pit_reset();
+void pit_reset(PIT *pit);
 void pit_set_gate(PIT *pit, int channel, int gate);
 void pit_set_using_timer(PIT *pit, int t, int using_timer);
 void pit_set_out_func(PIT *pit, int t, void (*func)(int new_out, int old_out));

--- a/src/scsi_53c400.c
+++ b/src/scsi_53c400.c
@@ -740,7 +740,8 @@ static void *scsi_rt1000b_init()
         return scsi_53c400_init("Rancho_RT1000_RTBios_version_8.10R.bin");
 }
 
-static void *scsi_t130b_init(char *bios_fn)
+/* Device init functions in the PCem framework take no parameters. */
+static void *scsi_t130b_init()
 {
         lcs6821n_t *scsi = malloc(sizeof(lcs6821n_t));
         memset(scsi, 0, sizeof(lcs6821n_t));

--- a/src/scsi_aha1540.c
+++ b/src/scsi_aha1540.c
@@ -2232,7 +2232,8 @@ static uint16_t port_sw_mapping[8] =
         0x330, 0x334, 0x230, 0x234, 0x130, 0x134, -1, -1
 };
 
-static void *scsi_aha1542c_init(char *bios_fn)
+/* Device initialisation functions should not take parameters. */
+static void *scsi_aha1542c_init()
 {
         aha154x_t *scsi = malloc(sizeof(aha154x_t));
         uint32_t addr;
@@ -2283,7 +2284,7 @@ static void *scsi_aha1542c_init(char *bios_fn)
         return scsi;
 }
 
-static void *scsi_bt545s_init(char *bios_fn)
+static void *scsi_bt545s_init()
 {
         aha154x_t *scsi = malloc(sizeof(aha154x_t));
         uint32_t addr;

--- a/src/sound_adlibgold.c
+++ b/src/sound_adlibgold.c
@@ -125,7 +125,7 @@ static int treble_cut[6] =
         (int)(0.354 * 16384)  /*-3 dB - filter output is at +6 dB*/
 };
 
-void adgold_timer_poll();
+void adgold_timer_poll(void *p);
 void adgold_update(adgold_t *adgold);
 
 void adgold_update_irq_status(adgold_t *adgold)

--- a/src/vid_s3.c
+++ b/src/vid_s3.c
@@ -156,7 +156,7 @@ typedef struct s3_t
 #define INT_FIFO_EMP (1 << 3)
 #define INT_MASK     0xf
 
-void s3_updatemapping();
+void s3_updatemapping(s3_t *s3);
 
 void s3_accel_write(uint32_t addr, uint8_t val, void *p);
 void s3_accel_write_w(uint32_t addr, uint16_t val, void *p);


### PR DESCRIPTION
## Summary
- add `-fcommon` to build flags for GCC 10+
- move more globals from `ibm.h` to `globals.c`
- declare those globals as `extern`

## Testing
- `./configure --enable-release-build`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_687a9558b294832cb8ab01c40b876e30