### PR TITLE
Add WHPX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The menu is a pop-up menu in the Linux/BSD port. Right-click on the main window 
 captured.
 
 CD-ROM support currently only accesses `/dev/cdrom`. It has not been heavily tested.
+Windows builds can optionally use the Windows Hypervisor Platform for faster CPU emulation via the `whpx` CPU type.
 
 ## Links
 

--- a/includes/private/cpu/cpu.h
+++ b/includes/private/cpu/cpu.h
@@ -48,6 +48,7 @@ extern int fpu_type;
 #define CPU_CELERON 30
 #define CPU_CELERON_A 31
 #define CPU_CYRIX_III 32
+#define CPU_WHPX 33
 
 #define MANU_INTEL 0
 #define MANU_AMD 1
@@ -97,6 +98,7 @@ extern CPU cpus_K6_SS7[];
 extern CPU cpus_PentiumPro[];
 extern CPU cpus_Slot1_100MHz[];
 extern CPU cpus_VIA_100MHz[];
+extern CPU cpus_WHPX[];
 
 extern CPU cpus_pcjr[];
 extern CPU cpus_europc[];
@@ -177,5 +179,9 @@ int fpu_get_type(int model, int manu, int cpu, const char *internal_name);
 const char *fpu_get_internal_name(int model, int manu, int cpu, int type);
 const char *fpu_get_name_from_index(int model, int manu, int cpu, int c);
 int fpu_get_type_from_index(int model, int manu, int cpu, int c);
+
+void whpx_init(void);
+void whpx_run(int cycles);
+void whpx_shutdown(void);
 
 #endif /* _CPU_H_ */

--- a/includes/public/pcem/cpu.h
+++ b/includes/public/pcem/cpu.h
@@ -64,5 +64,6 @@ extern CPU cpus_K6_SS7[];
 extern CPU cpus_PentiumPro[];
 extern CPU cpus_Slot1_100MHz[];
 extern CPU cpus_VIA_100MHz[];
+extern CPU cpus_WHPX[];
 
 #endif /* _PCEM_CPU_H_ */

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -1125,6 +1125,10 @@ void cpu_set() {
                 codegen_timing_set(&codegen_timing_cyrixiii);
                 break;
 
+        case CPU_WHPX:
+                /* WHPX acceleration uses host execution */
+                break;
+
         default:
                 fatal("cpu_set : unknown CPU type %i\n", cpu_s->cpu_type);
         }
@@ -1698,6 +1702,11 @@ void cpu_CPUID() {
                         break;
                 }
                 break;
+
+        case CPU_WHPX:
+                /* CPUID not emulated */
+                EAX = EBX = ECX = EDX = 0;
+                break;
         }
 }
 
@@ -1732,6 +1741,9 @@ void cpu_RDMSR() {
                         EAX = cpu_multi & 3;
                         break;
                 }
+                break;
+
+        case CPU_WHPX:
                 break;
 
         case CPU_PENTIUM:
@@ -1840,6 +1852,9 @@ void cpu_WRMSR() {
                         msr.fcr3 = EAX | ((uint64_t)EDX << 32);
                         break;
                 }
+                break;
+
+        case CPU_WHPX:
                 break;
 
         case CPU_PENTIUM:

--- a/src/cpu/cpu.cmake
+++ b/src/cpu/cpu.cmake
@@ -62,4 +62,9 @@ set(PCEM_SRC ${PCEM_SRC}
         cpu/x86seg.c
         cpu/x87.c
         cpu/x87_timings.c
+        cpu/whpx.c
         )
+
+if(WIN32)
+        set(PCEM_ADDITIONAL_LIBS ${PCEM_ADDITIONAL_LIBS} WinHvPlatform WinHvEmulation)
+endif()

--- a/src/cpu/cpu_tables.c
+++ b/src/cpu/cpu_tables.c
@@ -665,3 +665,8 @@ CPU cpus_VIA_100MHz[] = {
                 {"C3/800",        CPU_CYRIX_III, fpus_builtin, 20, 800000000, 3, 33333333, 0x673, 0x673, 0, CPU_SUPPORTS_DYNAREC |
            CPU_REQUIRES_DYNAREC, 18,18,9,9, 100},*/
         {"", -1, 0, 0, 0}};
+
+CPU cpus_WHPX[] = {
+        {"WHPX", CPU_WHPX, fpus_builtin, 20, 1000000000, 3, 33333333, 0, 0, 0,
+         0, 18, 18, 9, 9, 64},
+        {"", -1, 0, 0, 0}};

--- a/src/cpu/whpx.c
+++ b/src/cpu/whpx.c
@@ -1,0 +1,202 @@
+#ifdef _WIN32
+#include <Windows.h>
+#include <WinHvPlatform.h>
+#include <WinHvEmulation.h>
+#endif
+#include "ibm.h"
+#include "cpu.h"
+#include "mem.h"
+
+#ifdef _WIN32
+static WHV_EMULATOR_HANDLE whpx_emulator;
+static WHV_PARTITION_HANDLE whpx_partition;
+static void *whpx_mem;
+static UINT64 whpx_mem_size;
+
+static HRESULT CALLBACK whpx_io_cb(void *ctx, WHV_EMULATOR_IO_ACCESS_INFO *io)
+{
+    (void)ctx;
+    if (io->Direction)
+    {
+        switch (io->AccessSize)
+        {
+        case 1: outb((uint16_t)io->Port, (uint8_t)io->Data); break;
+        case 2: outw((uint16_t)io->Port, (uint16_t)io->Data); break;
+        case 4: outl((uint16_t)io->Port, (uint32_t)io->Data); break;
+        }
+    }
+    else
+    {
+        uint32_t val = 0;
+        switch (io->AccessSize)
+        {
+        case 1: val = inb((uint16_t)io->Port); break;
+        case 2: val = inw((uint16_t)io->Port); break;
+        case 4: val = inl((uint16_t)io->Port); break;
+        }
+        io->Data = val;
+    }
+    return S_OK;
+}
+
+static HRESULT CALLBACK whpx_mmio_cb(void *ctx, WHV_EMULATOR_MEMORY_ACCESS_INFO *mem)
+{
+    (void)ctx;
+    UINT64 addr = mem->GpaAddress;
+    for (UINT32 i = 0; i < mem->AccessSize; i++) {
+        if (mem->Direction)
+            mem_writeb_phys((uint32_t)addr + i, ((uint8_t *)mem->Data)[i]);
+        else
+            ((uint8_t *)mem->Data)[i] = mem_readb_phys((uint32_t)addr + i);
+    }
+    return S_OK;
+}
+
+static HRESULT CALLBACK whpx_get_regs_cb(void *ctx, const WHV_REGISTER_NAME *names,
+                                         UINT32 count, WHV_REGISTER_VALUE *values)
+{
+    (void)ctx;
+    return WHvGetVirtualProcessorRegisters(whpx_partition, 0, names, count, values);
+}
+
+static HRESULT CALLBACK whpx_set_regs_cb(void *ctx, const WHV_REGISTER_NAME *names,
+                                         UINT32 count, const WHV_REGISTER_VALUE *values)
+{
+    (void)ctx;
+    return WHvSetVirtualProcessorRegisters(whpx_partition, 0, names, count, values);
+}
+
+static HRESULT CALLBACK whpx_translate_cb(void *ctx, WHV_GUEST_VIRTUAL_ADDRESS gva,
+                                          WHV_TRANSLATE_GVA_FLAGS flags,
+                                          WHV_TRANSLATE_GVA_RESULT_CODE *result,
+                                          WHV_GUEST_PHYSICAL_ADDRESS *gpa)
+{
+    (void)ctx;
+    WHV_TRANSLATE_GVA_RESULT r;
+    HRESULT hr = WHvTranslateGva(whpx_partition, 0, gva, flags, &r, gpa);
+    *result = r.ResultCode;
+    return hr;
+}
+#endif /* _WIN32 */
+
+void whpx_init(void)
+{
+#ifdef _WIN32
+    WHV_CAPABILITY cap = {0};
+    UINT32 ret_len = 0;
+    HRESULT hr = WHvGetCapability(WHvCapabilityCodeHypervisorPresent, &cap,
+                                   sizeof(cap), &ret_len);
+    if (FAILED(hr) || !cap.HypervisorPresent) {
+        pclog("whpx: hypervisor not present\n");
+        return;
+    }
+
+    WHV_EMULATOR_CALLBACKS cbs = {0};
+    cbs.Size = sizeof(cbs);
+    cbs.WHvEmulatorIoPortCallback = whpx_io_cb;
+    cbs.WHvEmulatorMemoryCallback = whpx_mmio_cb;
+    cbs.WHvEmulatorGetVirtualProcessorRegisters = whpx_get_regs_cb;
+    cbs.WHvEmulatorSetVirtualProcessorRegisters = whpx_set_regs_cb;
+    cbs.WHvEmulatorTranslateGvaPage = whpx_translate_cb;
+
+    hr = WHvEmulatorCreateEmulator(&cbs, &whpx_emulator);
+    if (FAILED(hr)) {
+        pclog("whpx: emulator create failed %lx\n", (unsigned long)hr);
+        return;
+    }
+
+    hr = WHvCreatePartition(&whpx_partition);
+    if (FAILED(hr)) {
+        pclog("whpx: create partition failed %lx\n", (unsigned long)hr);
+        WHvEmulatorDestroyEmulator(whpx_emulator);
+        whpx_emulator = NULL;
+        return;
+    }
+
+    UINT32 count = 1;
+    WHvSetPartitionProperty(whpx_partition, WHvPartitionPropertyCodeProcessorCount,
+                            &count, sizeof(count));
+    WHvSetupPartition(whpx_partition);
+
+    whpx_mem_size = (UINT64)mem_size * 1024 + 0x100000;
+    whpx_mem = VirtualAlloc(NULL, (SIZE_T)whpx_mem_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    if (!whpx_mem) {
+        pclog("whpx: memory alloc failed\n");
+        WHvDeletePartition(whpx_partition);
+        WHvEmulatorDestroyEmulator(whpx_emulator);
+        whpx_partition = NULL;
+        whpx_emulator = NULL;
+        return;
+    }
+
+    WHvMapGpaRange(whpx_partition, whpx_mem, 0, whpx_mem_size,
+                   WHvMapGpaRangeFlagRead | WHvMapGpaRangeFlagWrite | WHvMapGpaRangeFlagExecute);
+
+    WHvCreateVirtualProcessor(whpx_partition, 0, 0);
+
+    WHV_REGISTER_NAME names[] = {WHvX64RegisterRip, WHvX64RegisterRflags,
+                                WHvX64RegisterCs, WHvX64RegisterRax};
+    WHV_REGISTER_VALUE values[4] = {0};
+    values[0].Reg64 = 0xffff0; /* reset vector */
+    values[1].Reg64 = 0x2;     /* default flags */
+    values[2].Segment.Selector = 0xf000;
+    values[2].Segment.Base = 0xf0000;
+    values[2].Segment.Limit = 0xffff;
+    values[2].Segment.Attributes = 0x93;
+    values[3].Reg64 = 0;
+    WHvSetVirtualProcessorRegisters(whpx_partition, 0, names, 4, values);
+
+    pclog("whpx: initialized\n");
+#else
+    pclog("whpx: not supported\n");
+#endif
+}
+
+void whpx_run(int ncycles)
+{
+#ifdef _WIN32
+    WHV_RUN_VP_EXIT_CONTEXT exitctx;
+    for (int i = 0; i < ncycles; ) {
+        HRESULT hr = WHvRunVirtualProcessor(whpx_partition, 0, &exitctx, sizeof(exitctx));
+        if (FAILED(hr)) break;
+        switch (exitctx.ExitReason) {
+        case WHvRunVpExitReasonX64IoPortAccess:
+            WHvEmulatorTryIoEmulation(whpx_emulator, NULL, &exitctx.VpContext,
+                                      &exitctx.IoPortAccess, NULL);
+            break;
+        case WHvRunVpExitReasonMemoryAccess:
+            WHvEmulatorTryMmioEmulation(whpx_emulator, NULL, &exitctx.VpContext,
+                                        &exitctx.MemoryAccess, NULL);
+            break;
+        case WHvRunVpExitReasonX64Halt:
+            i = ncycles; /* exit */
+            break;
+        default:
+            i = ncycles;
+            break;
+        }
+        i++;
+    }
+#else
+    (void)ncycles;
+#endif
+}
+
+void whpx_shutdown(void)
+{
+#ifdef _WIN32
+    if (whpx_partition) {
+        WHvDeleteVirtualProcessor(whpx_partition, 0);
+        WHvDeletePartition(whpx_partition);
+        whpx_partition = NULL;
+    }
+    if (whpx_mem) {
+        VirtualFree(whpx_mem, 0, MEM_RELEASE);
+        whpx_mem = NULL;
+    }
+    if (whpx_emulator) {
+        WHvEmulatorDestroyEmulator(whpx_emulator);
+        whpx_emulator = NULL;
+    }
+#endif
+}

--- a/src/models/model.c
+++ b/src/models/model.c
@@ -774,12 +774,16 @@ MODEL m_super16te = {"[8088] Hyundai Super16TE",
                       64,
                       xt_init,
                       NULL};
-MODEL m_ibmpc = {"[8088] IBM PC", ROM_IBMPC, "ibmpc", {{"", cpus_8088}, {"", NULL}, {"", NULL}}, MODEL_GFX_NONE, 64, 640, 32,
+MODEL m_ibmpc = {"[8088] IBM PC", ROM_IBMPC, "ibmpc",
+                 {{"", cpus_8088}, {"whpx", cpus_WHPX}, {"", NULL}},
+                 MODEL_GFX_NONE, 64, 640, 32,
                  xt_init,         NULL};
 MODEL m_ibmpcjr = {"[8088] IBM PCjr", ROM_IBMPCJR, "ibmpcjr", {{"", cpus_pcjr}, {"", NULL}, {"", NULL}},
                    MODEL_GFX_FIXED,   128,         640,       64,
                    pcjr_init,         &pcjr_device};
-MODEL m_ibmxt = {"[8088] IBM XT", ROM_IBMXT, "ibmxt", {{"", cpus_8088}, {"", NULL}, {"", NULL}}, MODEL_GFX_NONE, 64, 640, 64,
+MODEL m_ibmxt = {"[8088] IBM XT", ROM_IBMXT, "ibmxt",
+                 {{"", cpus_8088}, {"whpx", cpus_WHPX}, {"", NULL}},
+                 MODEL_GFX_NONE, 64, 640, 64,
                  xt_init,         NULL};
 MODEL m_jukopc = {"[8088] Juko XT clone",
                   ROM_JUKOPC,

--- a/src/pc.c
+++ b/src/pc.c
@@ -332,6 +332,8 @@ void initpc(int argc, char *argv[]) {
 
 void resetpc() {
         cpu_set();
+        if (models[model]->cpu[cpu_manufacturer].cpus[cpu].cpu_type == CPU_WHPX)
+                whpx_init();
         pc_reset();
         cpu_set_turbo(1);
         //        cpuspeed2=(AT)?2:1;
@@ -474,7 +476,9 @@ void runpc() {
 
         startblit();
 
-        if (is386) {
+        if (models[model]->cpu[cpu_manufacturer].cpus[cpu].cpu_type == CPU_WHPX) {
+                whpx_run(cycles_to_run);
+        } else if (is386) {
                 if (cpu_use_dynarec)
                         exec386_dynarec(cycles_to_run);
                 else
@@ -572,6 +576,8 @@ void speedchanged() {
 }
 
 void closepc() {
+        if (models[model]->cpu[cpu_manufacturer].cpus[cpu].cpu_type == CPU_WHPX)
+                whpx_shutdown();
         codegen_close();
         atapi->exit();
         //        ioctl_close();


### PR DESCRIPTION
## Summary
- add optional WHPX usage note in README
- define a CPU_WHPX constant and expose WHPX CPU table
- allow IBM PC/XT models to select the `whpx` CPU
- implement initialization, run loop and shutdown in `whpx.c`
- integrate WHPX in runtime logic and CPU tables
- link against WinHvPlatform/WinHvEmulation on Windows

## Testing
- `cmake -S . -B build` *(fails: Could not find SDL2Config.cmake)*


------
https://chatgpt.com/codex/tasks/task_e_687f615ddca0832c83dfaf59db68c288